### PR TITLE
Fix spacing in ly environment

### DIFF
--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -61,7 +61,7 @@
 \newkeyenvironment{ly}[staffsize=\staffsize][autres]{%
 \def\localstaffsize{\commandkey{staffsize}}%
 \compilerly%
-}{
+}{%
 \endcompilerly%
 }
 


### PR DESCRIPTION
this removes an extra space created after the score in a ly environment