### PR TITLE
Create a flag indicating that the file is being compile through lyluatex

### DIFF
--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -119,6 +119,7 @@ function entete_lilypond(facteur, largeur)
   (lambda ( . rest)
    (apply collect-scores-for-book rest)))
 
+#(define inside-lyluatex #t)
 
 #(set-global-staff-size %s)
 


### PR DESCRIPTION
This allows for the user to create conditional constructs inside their lilypond files so that they compile differently when compiled as a stand-alone document and as one which is included in a LaTeX document using lyluatex

Example: the following paper block sets the default paper size to a5 for stand alone documents while still allowing lyluatex to control the line width when used:

\paper {
	#(if (not (defined? 'inside-lyluatex))
	(set-paper-size "a5"))
}