### PR TITLE
WIP: #30: Correctly identify and handle failed LilyPond compilations

### DIFF
--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -202,7 +202,7 @@ function write_tex(output, new_score)
 \end{quote}
 
 ]])
-        print("\nScore failed to compile, insert placeholder.\n")
+        err("\nScore failed to compile, please check LilyPond input.\n")
         --[[ ensure the score gets recompiled next time --]]
         os.remove(output..'-systems.tex')
     end


### PR DESCRIPTION
This is a preliminary implementation of #30 that properly detects and handles cases where LilyPond fails to compile a score.

I *think* I correctly identify the case with both fragment and full-page scores (which is completely different), but the consequence is preliminary: at the current state of opening that pull request a failed score inserts a placeholder comment *in the output document*, and we should discuss what else we could do (so this isn't meant to be merged yet).

One suggestion that might be acceptable to both @rpspringuel 's and my perspective would be to rewrite the text that is written to LaTeX to include a file with a file name "compilation-failure.pdf" or similar. That way "plain" LaTeX would simply choke about the missing file while `musicexamples` would print that yellow box wtih "missing example file “compilation-failure” in it.

```
Add function is_compiled

This is first used to determine whether a score has to be recompiled.
Look for either OUTPUT.pdf (for fullpage) or a non-empty
OUTPUT-systems.tex (note that also failed LilyPond compilations
produce a -systems.tex file)

the -systems.tex file also has to be removed, otherwise next time it would
be considered as "already compiled".
```