### PR TITLE
Includepaths option

### DIFF
--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -69,12 +69,13 @@ function extract_size_arguments(line_width, staffsize)
 end
 
 function hash_output_filename(ly_code, line_width, staffsize, input_file)
-    filename = string.gsub(
+    local filename = string.gsub(
         md5.sumhexa(flatten_content(ly_code, input_file))..
         '-'..staffsize..'-'..line_width.n..line_width.u, '%.', '-'
     )
     local f = io.open(FILELIST, 'a')
-    f:write(filename, '\n')
+    if not input_file then input_file = '' end
+    f:write(filename, '\t', input_file, '\n')
     f:close()
     return TMP..'/'..filename
 end

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -14,22 +14,28 @@
 \newcommand{\lyluatex}{\textit{ly}\LuaTeX}
 
 % Options
-\DeclareStringOption[lilypond]{program}[lilypond]
-\DeclareStringOption[default]{line-width}[lilypond]
-\DeclareStringOption[tmp_ly]{tmpdir}[lilypond]
+\DeclareStringOption[lilypond]{program}
+\DeclareStringOption[default]{line-width}
+\DeclareStringOption[tmp_ly]{tmpdir}
+\DeclareStringOption{includepaths}
 \newcommand{\pt}{pt}
 \newcommand{\mm}{mm}
 \newcommand{\cm}{cm}
 \ProcessKeyvalOptions*
 % Lua Script
 \directlua{
-LILYPOND = '\luatexluaescapestring{\lyluatex@program}'
-TMP = '\luatexluaescapestring{\lyluatex@tmpdir}'
-dofile(kpse.find_file("lyluatex.lua"))}
-\directlua{}
+  TMP = '\luatexluaescapestring{\lyluatex@tmpdir}'
+  dofile(kpse.find_file("lyluatex.lua"))
+  ly_define_program('\luatexluaescapestring{\lyluatex@program}')
+  ly_define_includepaths('\luatexluaescapestring{\lyluatex@includepaths}')
+}
 \newcommand{\lilypondCmd}[1]{%
     \directlua{ly_define_program("\luatexluaescapestring{#1}")}%
     \def\lyluatex@program{#1}
+}
+\newcommand{\lilypondIncludePaths}[1]{%
+    \directlua{ly_define_includepaths('\luatexluaescapestring{#1}')}%
+    \def\lyluatex@includepaths{#1}
 }
 
 \def\defaultwidth{default}
@@ -60,8 +66,10 @@ dofile(kpse.find_file("lyluatex.lua"))}
     ,staffsize=\staffsize%
     ,line-width=\lilywidth%
     ,program=\lyluatex@program%
+    ,includepaths=\lyluatex@includepaths%
     ][other-options][1]{%
 \directlua{ly_define_program("\luatexluaescapestring{\commandkey{program}}")}%
+\directlua{ly_define_includepaths("\luatexluaescapestring{\commandkey{includepaths}}")}%
 \directlua{%
     lilypond_file(
         "\luatexluaescapestring{#1}",
@@ -72,6 +80,7 @@ dofile(kpse.find_file("lyluatex.lua"))}
     )%
 }%
 \directlua{ly_define_program("\luatexluaescapestring{\lyluatex@program}")}%
+\directlua{ly_define_includepaths("\luatexluaescapestring{\lyluatex@includepaths}")}%
 }
 
 % Base environment to include a LilyPond fragment integrated into
@@ -91,28 +100,34 @@ dofile(kpse.find_file("lyluatex.lua"))}
     staffsize=\staffsize%
     ,line-width=\lilywidth%
     ,program=\lyluatex@program%
+    ,includepaths=\lyluatex@includepaths%
     ][other-options][1]{%
 \directlua{ly_define_program("\luatexluaescapestring{\commandkey{program}}")}%
+\directlua{ly_define_includepaths("\luatexluaescapestring{\commandkey{includepaths}}")}%
 \def\localstaffsize{\commandkey{staffsize}}%
 \def\localwidth{\commandkey{line-width}}%
 \begin{compilerly}%
 {#1}
 \end{compilerly}%
 \directlua{ly_define_program("\luatexluaescapestring{\lyluatex@program}")}%
+\directlua{ly_define_includepaths("\luatexluaescapestring{\lyluatex@includepaths}")}%
 }
 
 \newkeyenvironment{ly}[%
     staffsize=\staffsize%
     ,line-width=\lilywidth%
     ,program=\lyluatex@program%
+    ,includepaths=\lyluatex@includepaths%
     ][other-options]{%
 \directlua{ly_define_program("\luatexluaescapestring{\commandkey{program}}")}%
+\directlua{ly_define_includepaths("\luatexluaescapestring{\commandkey{includepaths}}")}%
 \def\localstaffsize{\commandkey{staffsize}}%
 \def\localwidth{\commandkey{line-width}}%
 \compilerly%
 }{%
 \endcompilerly%
 \directlua{ly_define_program("\luatexluaescapestring{\lyluatex@program}")}%
+\directlua{ly_define_includepaths("\luatexluaescapestring{\lyluatex@includepaths}")}%
 }
 
 % Commands for compatibility with lilypond-book


### PR DESCRIPTION
To address #21, t's now possible to include files from custom paths by three means :

- `includepaths={path,otherpath}` package option ;
- `\lilypondIncludePaths{path,otherpath}` command ;
- `includepaths={path,otherpath}` option for usual commands.

`{ }` are mandatory only if there are several paths.
There mustn't be any whitespace after the comma.
All paths are relative to current dir.

Even though I don't think `\lilypondIncludePaths` and `includepaths` command option are that useful, they are so similar to `\lilypondCmd` that they were really easy to implement.