### PR TITLE
Fonts to lilypond

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ test:
 
 manual:
 	pandoc --pdf-engine=lualatex \
+				 -V fontfamily=libertine \
 		     -o lyluatex.pdf \
 				 lyluatex.md \
 				 && xdg-open lyluatex.pdf

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 test:
 	lualatex -interaction=nonstopmode -shell-escape test.tex
 
+manual:
+	pandoc --pdf-engine=lualatex \
+		     -o lyluatex.pdf \
+				 lyluatex.md \
+				 && xdg-open lyluatex.pdf
+
 ctan:
 	mkdir -p ./ctan/lyluatex
 	cp lyluatex.* LICENSE ./ctan/lyluatex/

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -115,7 +115,9 @@ function compile_lilypond_fragment(ly_code, staffsize, line_width, output, inclu
     run_lilypond(ly_code, output, include)
 end
 
+
 function lilypond_fragment_header(staffsize, line_width)
+    local fontdef = get_fonts()
     return string.format(
 [[%%File header
 \version "2.18.2"
@@ -131,12 +133,18 @@ function lilypond_fragment_header(staffsize, line_width)
 \paper{
     indent = 0\mm
     line-width = %s\%s
+    #(define fonts
+      (make-pango-font-tree "%s"
+                            "%s"
+                            "%s"
+                            (/ staff-height pt 20)))
 }
 
 %%Follows original score
 ]],
 staffsize,
-line_width.n, line_width.u
+line_width.n, line_width.u,
+fontdef.rm, fontdef.sf, fontdef.tt
 )
 end
 
@@ -245,6 +253,18 @@ function fontinfo(id)
         return f
     end
     return font.fonts[id]
+end
+
+
+function get_fonts()
+    --[[ This is preliminary and simply retrieves then
+         font that is *currently* in use. --]]
+    local family = fontinfo(font.current()).shared.rawdata.metadata['familyname']
+    return {
+      ['rm'] = family,
+      ['sf'] = family,
+      ['tt'] = family,
+    }
 end
 
 

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -109,6 +109,7 @@ function run_lilypond(ly_code, output, include)
         "-dno-delete-intermediate-files "
     if include then cmd = cmd.."-I '"..lfs.currentdir().."/"..include.."' " end
     cmd = cmd.."-o "..output.." -"
+    print(cmd)
     local p = io.popen(cmd, 'w')
     p:write(ly_code)
     p:close()
@@ -322,14 +323,25 @@ function fontinfo(id)
     return font.fonts[id]
 end
 
+function get_current_font_family()
+    return fontinfo(font.current()).shared.rawdata.metadata['familyname']
+end
 
 function get_fonts()
     --[[ This is preliminary and simply retrieves then
          font that is *currently* in use. --]]
-    local family = fontinfo(font.current()).shared.rawdata.metadata['familyname']
-    return {
-      ['rm'] = family,
-      ['sf'] = family,
-      ['tt'] = family,
-    }
+    result = {}
+    tex.print('\noexpand\\begingroup')
+    tex.sprint('\noexpand\\rmfamily')
+    result.rm = get_current_font_family()
+    tex.sprint('\noexpand\\sffamily')
+    result.sf = get_current_font_family()
+    tex.sprint('\noexpand\\ttfamily')
+    result.tt = get_current_font_family()
+    tex.print('\noexpand\\endgroup')
+    print("")
+    print(result.rm)
+    print(result.sf)
+    print(result.tt)
+    return result
 end

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -122,7 +122,6 @@ end
 
 
 function lilypond_fragment_header(staffsize, line_width)
-    local fontdef = get_fonts()
     return string.format(
         [[
 %%File header
@@ -150,7 +149,9 @@ function lilypond_fragment_header(staffsize, line_width)
 ]],
 staffsize,
 line_width.n, line_width.u,
-fontdef.rm, fontdef.sf, fontdef.tt
+get_local_option('rmfamily'),
+get_local_option('sffamily'),
+get_local_option('ttfamily')
 )
 end
 
@@ -323,25 +324,6 @@ function fontinfo(id)
     return font.fonts[id]
 end
 
-function get_current_font_family()
-    return fontinfo(font.current()).shared.rawdata.metadata['familyname']
-end
-
-function get_fonts()
-    --[[ This is preliminary and simply retrieves then
-         font that is *currently* in use. --]]
-    result = {}
-    tex.print('\noexpand\\begingroup')
-    tex.sprint('\noexpand\\rmfamily')
-    result.rm = get_current_font_family()
-    tex.sprint('\noexpand\\sffamily')
-    result.sf = get_current_font_family()
-    tex.sprint('\noexpand\\ttfamily')
-    result.tt = get_current_font_family()
-    tex.print('\noexpand\\endgroup')
-    print("")
-    print(result.rm)
-    print(result.sf)
-    print(result.tt)
-    return result
+function get_font_family(font_id)
+    return fontinfo(font_id).shared.rawdata.metadata['familyname']
 end

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -123,6 +123,8 @@ end
 
 function define_lilypond_fonts()
     if get_local_option('pass-fonts') == 'true' then
+        if get_local_option('current-font-as-main') == 'true' then
+            LOCAL_OPTIONS.rmfamily = get_local_option('current-font') end
         return string.format([[
         #(define fonts
           (make-pango-font-tree "%s"

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -121,6 +121,21 @@ function compile_lilypond_fragment(ly_code, staffsize, line_width, output, inclu
 end
 
 
+function define_lilypond_fonts()
+    if get_local_option('pass-fonts') == 'true' then
+        return string.format([[
+        #(define fonts
+          (make-pango-font-tree "%s"
+                                "%s"
+                                "%s"
+                                (/ staff-height pt 20)))
+        ]],
+        get_local_option('rmfamily'),
+        get_local_option('sffamily'),
+        get_local_option('ttfamily'))
+    else return '' end
+end
+
 function lilypond_fragment_header(staffsize, line_width)
     return string.format(
         [[
@@ -138,20 +153,14 @@ function lilypond_fragment_header(staffsize, line_width)
 \paper{
     indent = 0\mm
     line-width = %s\%s
-    #(define fonts
-      (make-pango-font-tree "%s"
-                            "%s"
-                            "%s"
-                            (/ staff-height pt 20)))
+    %s
 }
 
 %%Follows original score
 ]],
 staffsize,
 line_width.n, line_width.u,
-get_local_option('rmfamily'),
-get_local_option('sffamily'),
-get_local_option('ttfamily')
+define_lilypond_fonts()
 )
 end
 

--- a/lyluatex.md
+++ b/lyluatex.md
@@ -2,7 +2,7 @@
 documentclass: lyluatexmanual
 title: "\\lyluatex"
 author:
-- Jacques Peron
+- Fr. Jacques Peron
 - Urs Liska
 - Br. Samuel Springuel
 toc: yes

--- a/lyluatex.md
+++ b/lyluatex.md
@@ -11,3 +11,40 @@ abstract: >
 ---
 
 # Introduction
+
+# Font Handling
+
+The choice of fonts is arguably the most obvious factor in the appearance of any
+document, be it text or music.  In text documents with interspersed scores the
+text fonts should be consistent between text and music sections. \lyluatex\ can
+handle this automatically by passing the used text fonts to LilyPond, so the
+user doesn't have to worry about keeping the scores' fonts in sync with the text
+document.
+
+Before generating any score \lyluatex\ retrieves the currently defined fonts for
+\cmd{rmfamily}, \cmd{sffamily}, and \cmd{ttfamily}, as well as the font that is
+currently in use for typesetting.  By default the *current* font is used as the
+roman font in LilyPond, while sans and mono fonts are passed to their
+corresponding families.  This ensures that the score's main font is consistent
+with the surrounding text.  However, this behaviour may not be desirable because
+it effectively removes the roman font from the LilyPond score, and it may make
+the *scores* look inconsistent with each other.  Therefore \lyluatex\ can also
+just pass the three font families to their LilyPond counterparts.  If fonts are
+explicitly defined in a \cmd{paper \{\}} block in the LilyPond input this takes
+precedence over the automatically transferred fonts.
+
+\lyIssue{Note:} So far only the main *font family* is used by LilyPond, but it is intended to add support for OpenType features in the future.
+
+\lyIssue{Note:} LilyPond handles font selection differently from \LuaTeX and can
+only look up fonts that are installed as system fonts. For any font that is
+installed in the `texmf` tree LilyPond will use an arbitrary fallback font.
+However, it doesn't matter whether the fonts are selected by their family or
+file names.
+
+Scores that differ *only* by their fonts are considered different by
+\lyluatex\ and therefore recompiled correctly.
+
+\lyOption{pass-fonts}{true}{pkg/local} When set to `false` text fonts are *not*
+transferred to LilyPond.
+
+\lyCmd{lilypondPassFonts}{1} Change behaviour from here on. Possible values: ‘true’ / ‘false’.

--- a/lyluatex.md
+++ b/lyluatex.md
@@ -1,0 +1,13 @@
+---
+documentclass: lyluatexmanual
+title: "\\lyluatex"
+author:
+- Jacques Peron
+- Urs Liska
+- Br. Samuel Springuel
+toc: yes
+abstract: >
+  \lyluatex\ is a \LaTeX package that \dots
+---
+
+# Introduction

--- a/lyluatex.md
+++ b/lyluatex.md
@@ -12,7 +12,47 @@ abstract: >
 
 # Introduction
 
-# Font Handling
+* General idea
+* Main features
+* lilypond-book
+* Minimal Working Example
+
+## Installation
+
+# Usage
+
+* Basic operation with the three commands/environments
+* Subsection: lilypond-book compatibility chart
+
+## Option Handling
+
+* Including conventions in this manual
+
+## Score Layout
+
+### `line-width`
+
+### `staffsize`
+
+### Full Page Scores and Fragments
+
+### Alignment
+
+## Miscellaneous Options
+
+### LilyPond Include Paths
+
+### LilyPond Executable
+
+### Temp Directory for scores
+
+* tmpdir
+* cleantmp
+
+### Handling Failed LilyPond Compilations
+
+
+## Font Handling
 
 The choice of fonts is arguably the most obvious factor in the appearance of any
 document, be it text or music.  In text documents with interspersed scores the

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -22,7 +22,8 @@
     ['tmpdir'] = 'tmp_ly',
     ['showfailed'] = 'true',
     ['staffsize'] = '0',
-    ['line-width'] = 'default'
+    ['line-width'] = 'default',
+    ['pass-fonts'] = 'true'
   } )
   set_default_options()
   reset_local_options()
@@ -59,7 +60,11 @@
   \edef\lyluatex@line-width{#1}
   \directlua{set_option('line-width', #1)}
 }
+\newcommand{\lilypondPassFonts}[1]{%
+  \directlua{set_option('pass-fonts', #1)}
+}
 \catcode`-=12
+
 
 % Retrieve the three main font families (rm, sf, tt)
 % and store them as options. Additionally store the
@@ -85,6 +90,7 @@
     ,staffsize%
     ,line-width%
     ,program%
+    ,pass-fonts%
     ][other-options][1]{%
 \calclinewidth
 \currentfonts
@@ -92,7 +98,8 @@
     set_local_options({
       ['lilypondcmd'] = '\luatexluaescapestring{\commandkey{program}}',
       ['line-width'] = '\luatexluaescapestring{\commandkey{line-width}}',
-      ['staffsize'] = '\luatexluaescapestring{\commandkey{staffsize}}'
+      ['staffsize'] = '\luatexluaescapestring{\commandkey{staffsize}}',
+      ['pass-fonts'] = '\luatexluaescapestring{\commandkey{pass-fonts}}'
     })
     lilypond_file(
         "\luatexluaescapestring{#1}",
@@ -120,12 +127,14 @@
     staffsize%
     ,line-width%
     ,program%
+    ,pass-fonts%
     ][other-options][1]{%
 \directlua{
     set_local_options({
       ['lilypondcmd'] = '\luatexluaescapestring{\commandkey{program}}',
       ['line-width'] = '\luatexluaescapestring{\commandkey{line-width}}',
-      ['staffsize'] = '\luatexluaescapestring{\commandkey{staffsize}}'
+      ['staffsize'] = '\luatexluaescapestring{\commandkey{staffsize}}',
+      ['pass-fonts'] = '\luatexluaescapestring{\commandkey{pass-fonts}}'
     })
 }
 \begin{compilerly}%
@@ -138,12 +147,14 @@
     staffsize%
     ,line-width%
     ,program%
+    ,pass-fonts%
     ][other-options]{%
 \directlua{
     set_local_options({
       ['lilypondcmd'] = '\luatexluaescapestring{\commandkey{program}}',
       ['line-width'] = '\luatexluaescapestring{\commandkey{line-width}}',
-      ['staffsize'] = '\luatexluaescapestring{\commandkey{staffsize}}'
+      ['staffsize'] = '\luatexluaescapestring{\commandkey{staffsize}}',
+      ['pass-fonts'] = '\luatexluaescapestring{\commandkey{pass-fonts}}'
     })
 }
 \compilerly%

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -23,7 +23,8 @@
     ['showfailed'] = 'true',
     ['staffsize'] = '0',
     ['line-width'] = 'default',
-    ['pass-fonts'] = 'true'
+    ['pass-fonts'] = 'true',
+    ['current-font-as-main'] = 'true'
   } )
   set_default_options()
   reset_local_options()
@@ -63,6 +64,9 @@
 \newcommand{\lilypondPassFonts}[1]{%
   \directlua{set_option('pass-fonts', #1)}
 }
+\newcommand{\lilypondCurrentFontAsMain}[1]{%
+  \directlua{set_option('current-font-as-main', #1)}
+}
 \catcode`-=12
 
 
@@ -71,6 +75,7 @@
 % *current* font for optional use.
 \newcommand{\currentfonts}{%
 \begingroup%
+    \directlua{set_option('current-font', get_font_family(font.current()))}
     \rmfamily \edef\rmfamilyid{\fontid\font}%
     \sffamily \edef\sffamilyid{\fontid\font}%
     \ttfamily \edef\ttfamilyid{\fontid\font}%
@@ -78,7 +83,6 @@
         set_option('rmfamily', get_font_family(\rmfamilyid))
         set_option('sffamily', get_font_family(\sffamilyid))
         set_option('ttfamily', get_font_family(\ttfamilyid))
-        set_option('current-font', get_font_family(font.current()))
     }%
 \endgroup%
 }
@@ -91,6 +95,7 @@
     ,line-width%
     ,program%
     ,pass-fonts%
+    ,current-font-as-main%
     ][other-options][1]{%
 \calclinewidth
 \currentfonts
@@ -99,7 +104,8 @@
       ['lilypondcmd'] = '\luatexluaescapestring{\commandkey{program}}',
       ['line-width'] = '\luatexluaescapestring{\commandkey{line-width}}',
       ['staffsize'] = '\luatexluaescapestring{\commandkey{staffsize}}',
-      ['pass-fonts'] = '\luatexluaescapestring{\commandkey{pass-fonts}}'
+      ['pass-fonts'] = '\luatexluaescapestring{\commandkey{pass-fonts}}',
+      ['current-font-as-main'] = '\luatexluaescapestring{\commandkey{current-font-as-main}}'
     })
     lilypond_file(
         "\luatexluaescapestring{#1}",
@@ -128,13 +134,15 @@
     ,line-width%
     ,program%
     ,pass-fonts%
+    ,current-font-as-main%
     ][other-options][1]{%
 \directlua{
     set_local_options({
       ['lilypondcmd'] = '\luatexluaescapestring{\commandkey{program}}',
       ['line-width'] = '\luatexluaescapestring{\commandkey{line-width}}',
       ['staffsize'] = '\luatexluaescapestring{\commandkey{staffsize}}',
-      ['pass-fonts'] = '\luatexluaescapestring{\commandkey{pass-fonts}}'
+      ['pass-fonts'] = '\luatexluaescapestring{\commandkey{pass-fonts}}',
+      ['current-font-as-main'] = '\luatexluaescapestring{\commandkey{current-font-as-main}}'
     })
 }
 \begin{compilerly}%
@@ -148,13 +156,15 @@
     ,line-width%
     ,program%
     ,pass-fonts%
+    ,current-font-as-main%
     ][other-options]{%
 \directlua{
     set_local_options({
       ['lilypondcmd'] = '\luatexluaescapestring{\commandkey{program}}',
       ['line-width'] = '\luatexluaescapestring{\commandkey{line-width}}',
       ['staffsize'] = '\luatexluaescapestring{\commandkey{staffsize}}',
-      ['pass-fonts'] = '\luatexluaescapestring{\commandkey{pass-fonts}}'
+      ['pass-fonts'] = '\luatexluaescapestring{\commandkey{pass-fonts}}',
+      ['current-font-as-main'] = '\luatexluaescapestring{\commandkey{current-font-as-main}}'
     })
 }
 \compilerly%

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -61,6 +61,22 @@
 }
 \catcode`-=12
 
+% Retrieve the three main font families (rm, sf, tt)
+% and store them as options. Additionally store the
+% *current* font for optional use.
+\newcommand{\currentfonts}{%
+\begingroup%
+    \rmfamily \edef\rmfamilyid{\fontid\font}%
+    \sffamily \edef\sffamilyid{\fontid\font}%
+    \ttfamily \edef\ttfamilyid{\fontid\font}%
+    \directlua{
+        set_option('rmfamily', get_font_family(\rmfamilyid))
+        set_option('sffamily', get_font_family(\sffamilyid))
+        set_option('ttfamily', get_font_family(\ttfamilyid))
+        set_option('current-font', get_font_family(font.current()))
+    }%
+\endgroup%
+}
 
 % Main commands
 % Inclusion of a .ly file
@@ -71,6 +87,7 @@
     ,program%
     ][other-options][1]{%
 \calclinewidth
+\currentfonts
 \directlua{
     set_local_options({
       ['lilypondcmd'] = '\luatexluaescapestring{\commandkey{program}}',
@@ -90,6 +107,7 @@
 % the document.
 \NewEnviron{compilerly}{%
 \calclinewidth
+\currentfonts
 \directlua{%
     lilypond_fragment(
         "\luatexluaescapestring{\unexpanded\expandafter{\BODY}}"

--- a/lyluatexmanual.cls
+++ b/lyluatexmanual.cls
@@ -1,0 +1,34 @@
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesClass{lyluatexmanual}
+
+\LoadClass[DIV=11]{scrartcl}
+\usepackage{fontspec}
+\usepackage{microtype}
+\usepackage{libertine}
+\defaultfontfeatures{
+	Ligatures=TeX,
+	Scale=MatchLowercase,
+	Numbers=Proportional,
+	Numbers=OldStyle
+}
+\frenchspacing
+
+\usepackage{lyluatex}
+
+\newcommand{\cmd}[1]{%
+\textbackslash \texttt{#1}}
+
+\newcommand{\lyOption}[3]{%
+
+\medskip
+\hspace*{-1em}\textbf{#1} (#2) {\small \textit{#3}} ---\\}
+
+\newcommand{\lyCmd}[2]{%
+
+\medskip
+\hspace*{-1em}\textbf{\textbackslash #1} (#2 args)---\\}
+
+\newcommand{\lyIssue}[1]{%
+
+\medskip
+\hspace*{-1em}\textbf{\textcolor{red}{#1}}\\}

--- a/test-alignment.tex
+++ b/test-alignment.tex
@@ -6,6 +6,8 @@
 \usepackage{musicexamples}
 \setXmpCaptionLabel{Example}
 
+%\usepackage{fontspec}
+%\usepackage{Libertine}
 \usepackage{libertine}
 \usepackage{microtype}
 \frenchspacing
@@ -14,7 +16,6 @@
 \usepackage[top=2cm,bottom=3cm]{geometry}
 \usepackage{multicol}
 \usepackage[colorlinks]{hyperref}
-
 
 \newcommand{\betweenLilyPondSystem}[1]{
 
@@ -29,7 +30,6 @@
 \lyluatex%
 \footnote{\url{https://github.com/jperon/lyluatex}}
  is a package for \LuaLaTeX\ that manages the engraving and integration of musical scores in text documents. The scores are encoded in chunks of LilyPond input which can be written directly in the document or maintained in standalone files.  They are compiled using LilyPond and cached intelligently. Line width and staff size can be inferred from the surrounding text (but also configured explicitly). The following Beethoven excerpt is included twice, first normally and then with a smaller staff size in a two-column section:
-
 
 \begin{musicExampleNonFloat}
 \includely[staffsize=18]{ly/Beethoven/opus-18-1.ly}
@@ -58,9 +58,10 @@ The other aspect is that the resulting systems of the score are generated as ind
 
 But the main point of this document is to provide material for discussing the \emph{alignment} of scores to the surrounding text. The examples so far show an achievement of the \lyluatex\ package: when aligning the score to the text the \emph{staff lines} exactly match the line width of the text, while brackets and instrument names protrude into the left margin.  This is actually a non-trivial task, as the width of that margin material is arbitrary and can't reasonably be predicted, at least not automatically and reliably.  In order to properly handle that task \lyluatex\ reads that width from an intermediate PostScript file and applies the corresponding negative offset when including the image file for each system.
 
+\setmainfont{Adobe Garamond Pro}
+
 \bigskip
 However, while this is a great default behaviour there are valid reasons for \emph{not} wanting such protrusion to (always) happen.  For example it might be considered inappropriate to use the margin at all (maybe there are other elements to be printed in the margin) or it may look awkward or  actually run off the page when the margin text is very wide:
-
 
 \begin{musicExampleNonFloat}
 \begin{ly}


### PR DESCRIPTION
Fixes #32

Document fonts can now be injected into the LilyPond score:

* By default the *current* font will become the roman font in LilyPond
* but it can be set so the three families are passed directly
* can be switched on and off globally/locally and along the way

**Note:** So far works only for "fragments" as we don't inject *any* layout into included files, see #29 