### PR TITLE
Handling of boolean options (Help needed)

### DIFF
--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -358,8 +358,9 @@ end
 
 
 function get_local_option(name)
-    if LOCAL_OPTIONS[name] then
-        return LOCAL_OPTIONS[name]
+    local loc = LOCAL_OPTIONS[name]
+    if not type(loc) == 'nil' then
+        return loc
     else
         return OPTIONS[name]
     end

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -53,6 +53,30 @@ function extract_unit(input)
 end
 
 
+function check_boolean(name, val)
+    if type(val) == 'boolean' then return val end
+    if val == 'true' then return true
+    else
+        if val == 'false' then return false
+        else
+            warn("\nExpected boolean argument for '%s',\nvalue '%s' given instead.\nFall back to 'false'.", name, val)
+            return false
+        end
+    end
+end
+
+function check_boolean_option(key)
+    return check_boolean(key, get_option(key))
+end
+
+function check_boolean_options(keys)
+    for _, key in ipairs(keys) do
+      set_option(key, check_boolean_option(key))
+    end
+end
+
+
+
 function extract_includepaths(includepaths)
     includepaths = includepaths:explode(',')
     -- delete initial space (in case someone puts a space after the comma)
@@ -418,7 +442,7 @@ function define_lilypond_fonts()
 end
 
 function lilypond_set_roman_font()
-    if get_local_option('current-font-as-main') == 'true' then
+    if get_local_option('current-font-as-main') then
         LOCAL_OPTIONS.rmfamily = get_local_option('current-font') end
 end
 
@@ -427,7 +451,7 @@ function squash_fontname(family)
 end
 
 function fontify_output(output)
-    if get_local_option('pass-fonts') == 'true' then
+    if get_local_option('pass-fonts') then
         return output..'-'..
           squash_fontname('rmfamily')..'_'..
           squash_fontname('sffamily')..'_'..

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -18,7 +18,7 @@
 \directlua{
   dofile(kpse.find_file("lyluatex.lua"))
   declare_package_options( {
-    ['cleantmp'] = false,
+    ['cleantmp'] = 'false',
     ['current-font-as-main'] = 'true',
     ['includepaths'] = './',
     ['line-width'] = 'default',
@@ -32,7 +32,13 @@
   reset_local_options()
 }
 \directlua{
-  if get_option('cleantmp') == 'true' then
+  check_boolean_options({
+    'cleantmp',
+    'current-font-as-main',
+    'pass-fonts',
+    'showfailed'
+  })
+  if get_option('cleantmp') then
     luatexbase.add_to_callback('stop_run', clean_tmp_dir, 'lyluatex cleantmp')
     luatexbase.add_to_callback('stop_run', conclusion_text, 'lyluatex cleantmp')
   end

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -159,10 +159,10 @@
 \directlua{
     set_local_options({
     ['includepaths'] = '\luatexluaescapestring{\commandkey{includepaths}}',
-    ['current-font-as-main'] = '\luatexluaescapestring{\commandkey{current-font-as-main}}',
+    ['current-font-as-main'] = check_boolean('current-font-as-main', \commandkey{current-font-as-main}),
       ['lilypondcmd'] = '\luatexluaescapestring{\commandkey{program}}',
       ['line-width'] = '\luatexluaescapestring{\commandkey{line-width}}',
-      ['pass-fonts'] = '\luatexluaescapestring{\commandkey{pass-fonts}}',
+      ['pass-fonts'] = check_boolean('pass-fonts', \commandkey{pass-fonts}),
       ['staffsize'] = '\luatexluaescapestring{\commandkey{staffsize}}'
     })
 }
@@ -182,7 +182,7 @@
     ][other-options]{%
 \directlua{
     set_local_options({
-      ['current-font-as-main'] = '\luatexluaescapestring{\commandkey{current-font-as-main}}',
+      ['current-font-as-main'] = check_boolean('current-font-as-main', \luatexluaescapestring{\commandkey{current-font-as-main}}),
       ['includepaths'] = '\luatexluaescapestring{\commandkey{includepaths}}',
       ['lilypondcmd'] = '\luatexluaescapestring{\commandkey{program}}',
       ['line-width'] = '\luatexluaescapestring{\commandkey{line-width}}',


### PR DESCRIPTION
I found out that we didn't fully support boolean options (but used them via strings). This means we couldn't do `if get_option('something) then` but `if get_option('something) == 'true' then` - which effectively made *anything* except `'true'` a false value.

8a729333 partially fixes this - but it only works for package options.

With local options I didn't manage to get them to work at all. 3ca8f74c shows my attempts - the culprit is probably how to pass the `keycommand` options along into Lua.