### PR TITLE
Fullpage vertical align

### DIFF
--- a/ly/Beethoven/opus-18-1.ly
+++ b/ly/Beethoven/opus-18-1.ly
@@ -7,6 +7,7 @@
 }
 
 \header {
+  title=Beethoven
   % Remove default LilyPond tagline
   tagline = ##f
 }

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -158,27 +158,41 @@ function calc_margins()
     inner-margin = %s\pt
     ]]
 
-    local top = (
+    local tex_top = (
         tex.sp('1in') +
         tex.dimen.voffset +
         tex.dimen.topmargin +
         tex.dimen.headheight +
         tex.dimen.headsep
     )
-    local bottom = (
-        tex.dimen.paperheight - (top + tex.dimen.textheight)
+    local tex_bottom = (
+        tex.dimen.paperheight - (tex_top + tex.dimen.textheight)
     )
     local inner = (
         tex.sp('1in') +
         tex.dimen.oddsidemargin +
         tex.dimen.hoffset
     )
-    return string.format(
-      template,
-      top,
-      bottom,
-      inner
-    )
+    local v_align = get_local_option('fullpagealign')
+    if v_align == 'crop'
+    then
+        return string.format(
+          template,
+          tex_top,
+          tex_bottom,
+          inner
+        )
+    elseif v_align == 'staffline' then
+        err("not implemented yet")
+
+    else
+        err([[
+        Invalid argument for option 'fullpagealign'.
+        Allowed: 'crop', 'staffline'.
+        Given: %s
+        ]],
+        v_align)
+    end
 end
 
 function lilypond_fragment_header(staffsize, line_width, fullpage)
@@ -437,6 +451,7 @@ end
 local LOC_OPT_NAMES = {
     'current-font-as-main',
     'fullpage',
+    'fullpagealign',
     'fullpagestyle',
     'includepaths',
     'line-width',

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -152,6 +152,12 @@ function compile_lilypond_fragment(
 end
 
 function calc_margins()
+    local template = [[
+    top-margin = %s\pt
+    bottom-margin = %s\pt
+    inner-margin = %s\pt
+    ]]
+
     local top = (
         tex.sp('1in') +
         tex.dimen.voffset +
@@ -167,11 +173,12 @@ function calc_margins()
         tex.dimen.oddsidemargin +
         tex.dimen.hoffset
     )
-    return {
-        ['top'] = top,
-        ['bottom'] = bottom,
-        ['inner'] = inner
-    }
+    return string.format(
+      template,
+      top,
+      bottom,
+      inner
+    )
 end
 
 function lilypond_fragment_header(staffsize, line_width, fullpage)
@@ -220,13 +227,7 @@ function lilypond_fragment_header(staffsize, line_width, fullpage)
         first-page-number = %s]],
         ppn,
         PAGE)
-        lilymargin = 'top-margin = %s\\pt\nbottom-margin = %s\\pt\n'..
-            'inner-margin = %s\\pt'
-        local margins = calc_margins()
-        lilymargin = string.format(
-            lilymargin,
-            margins.top / 65536, margins.bottom / 65536, margins.inner / 65536
-        )
+        lilymargin = calc_margins()
     end
     header = header..
         string.format('\n'..

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -21,6 +21,7 @@
     ['cleantmp'] = 'false',
     ['current-font-as-main'] = 'true',
     ['fullpage'] = 'false',
+    ['fullpagealign'] = 'crop',
     ['fullpagestyle'] = 'default',
     ['includepaths'] = './',
     ['line-width'] = 'default',
@@ -96,6 +97,9 @@
 \newcommand{\lilypondFullpage}[1]{%
   \directlua{set_option('fullpage', #1)}
 }
+\newcommand{\lilypondFullpageAlign}[1]{%
+  \directlua{set_option('fullpagealign', '#1')}
+}
 \newcommand{\lilypondPassFonts}[1]{%
   \directlua{set_option('pass-fonts', #1)}
 }
@@ -135,6 +139,7 @@
 \newkeycommand*\includely[%
     current-font-as-main%
     ,fullpage%
+    ,fullpagealign%
     ,fullpagestyle%
     ,includepaths%
     ,line-width%
@@ -175,6 +180,7 @@
 \newkeycommand{\lily}[%
     current-font-as-main%
     ,fullpage%
+    ,fullpagealign%
     ,fullpagestyle%
     ,includepaths%
     ,line-width%
@@ -197,6 +203,7 @@
     current-font-as-main%
     ,fullpage%
     ,fullpagestyle%
+    ,fullpagealign%
     ,includepaths%
     ,line-width%
     ,pass-fonts%

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -21,7 +21,7 @@
     ['cleantmp'] = 'false',
     ['current-font-as-main'] = 'true',
     ['fullpage'] = 'false',
-    ['fullpagealign'] = 'crop',
+    ['fullpagealign'] = 'staffline',
     ['fullpagestyle'] = 'default',
     ['includepaths'] = './',
     ['line-width'] = 'default',

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -20,6 +20,8 @@
   declare_package_options( {
     ['cleantmp'] = 'false',
     ['current-font-as-main'] = 'true',
+    ['extra-bottom-margin'] = '0',
+    ['extra-top-margin'] = '0',
     ['fullpage'] = 'false',
     ['fullpagealign'] = 'staffline',
     ['fullpagestyle'] = 'default',
@@ -107,6 +109,12 @@
   \directlua{set_option('current-font-as-main', #1)}
 }
 \catcode`-=12
+\newcommand{\lilypondExtraTopMargin}[1]{
+    \directlua{set_option('extra-top-margin', '#1')}
+}
+\newcommand{\lilypondExtraBottomMargin}[1]{
+    \directlua{set_option('extra-bottom-margin', '#1')}
+}
 % Include paths for lilypond documents
 \newcommand{\lilypondIncludePaths}[1]{%
     \directlua{set_option('includepaths', '#1')}
@@ -138,6 +146,8 @@
 % Inclusion of a .ly file
 \newkeycommand*\includely[%
     current-font-as-main%
+    ,extra-bottom-margin%
+    ,extra-top-margin%
     ,fullpage%
     ,fullpagealign%
     ,fullpagestyle%
@@ -179,6 +189,8 @@
 % Parametrized command and environment for included LilyPond fragment
 \newkeycommand{\lily}[%
     current-font-as-main%
+    ,extra-bottom-margin%
+    ,extra-top-margin%
     ,fullpage%
     ,fullpagealign%
     ,fullpagestyle%
@@ -201,6 +213,8 @@
 
 \newkeyenvironment{ly}[%
     current-font-as-main%
+    ,extra-bottom-margin%
+    ,extra-top-margin%
     ,fullpage%
     ,fullpagestyle%
     ,fullpagealign%

--- a/test.tex
+++ b/test.tex
@@ -100,6 +100,10 @@ page\footnote{\lilypond[fragment]{a' b' c'}}.
 
 \end{multicols}
 
+\newpage
+
+Test pour alignement.
+
 \lilypondfile[fullpage=true,staffsize=16]{ly/Beethoven/opus-18-1.ly}
 
 \end{document}


### PR DESCRIPTION
This Pull Request implements vertical alignment for fullpage scores with two options:

* `fullpagealign=crop`
* `fullpagealign=staffline`
* `\lilypondFullpageAlign{crop/staffline}`

With `crop` the crop box of the LilyPond score is aligned to the typearea box of the text document:
![image](https://user-images.githubusercontent.com/1812148/35514433-6ebb9ce4-0506-11e8-9f2a-38ede55fda44.png)

With `staffline` the outermost lines of the staff symbol will be aligned, with any additional score items protruding into the margins:
![image](https://user-images.githubusercontent.com/1812148/35514392-51e214a4-0506-11e8-9245-22d4ef4b2e36.png)

I have set `staffline` to be the default because that is consistent how we handle the horizontal protrusion, and because I think that is what we want to have when thinking about beautiful book layout. But we can discuss that.

Probably we should have additional options `extra-top-margin` and `extra-bottom-margin` for manual adjustment for special scores with large protrusion.