### PR TITLE
Program flow and passing argument

### DIFF
--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -151,7 +151,10 @@ function process_lilypond_code()
     process_extra_margins()
     set_local_option('output', hash_output_filename())
     local do_compile = not is_compiled()
-    if do_compile then compile_lilypond_fragment() end
+    if do_compile then
+        apply_lilypond_header()
+        run_lilypond()
+    end
     write_tex(do_compile)
 end
 
@@ -193,10 +196,6 @@ function run_lilypond()
     p:close()
 end
 
-function compile_lilypond_fragment()
-    lilypond_fragment_header()
-    run_lilypond()
-end
 
 function process_extra_margins()
     local top_extra = get_local_option('extra-top-margin')
@@ -293,7 +292,7 @@ function calc_margins()
     end
 end
 
-function lilypond_fragment_header()
+function apply_lilypond_header()
     local line_width = get_local_option('line-width')
     local staffsize = get_local_option('staffsize')
     local fullpage = get_local_option('fullpage')

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -164,7 +164,7 @@ function lilypond_file(input_file)
     local i = io.open(input_file, 'r')
     ly_code = i:read('*a')
     i:close()
-    LOCAL_OPTIONS['input-file'] = input_file
+    set_local_option('input-file', input_file)
     process_lilypond_code(ly_code)
 end
 
@@ -199,14 +199,14 @@ function process_extra_margins()
         local margin = extract_unit(top_extra)
         top = convert_unit(margin.n, margin.u, 'pt')
     end
-    LOCAL_OPTIONS['extra-top-margin'] = top
+    set_local_option('extra-top-margin', top)
     local bottom_extra = get_local_option('extra-bottom-margin')
     local bottom = tonumber(bottom_extra)
     if not bottom then
         local margin = extract_unit(bottom_extra)
         bottom = convert_unit(margin.n, margin.u, 'pt')
     end
-    LOCAL_OPTIONS['extra-bottom-margin'] = bottom
+    set_local_option('extra-bottom-margin', bottom)
 end
 
 function pt_to_staffspaces(pt, staffsize)
@@ -529,6 +529,12 @@ function set_default_options()
             )
         )
     end
+end
+
+
+function set_local_option(name, value)
+    if value == 'false' then value = false end
+    LOCAL_OPTIONS[name] = value
 end
 
 

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -167,7 +167,7 @@ end
 
 function lilypond_file(input_file)
     filename = splitext(input_file, 'ly')
-    input_file = CURRENTDIR..filename..'.ly'
+    input_file = CURFILEDIR..filename..'.ly'
     if not lfs.isfile(input_file) then input_file = kpse.find_file(filename..'.ly') end
     if not lfs.isfile(input_file) then err("File %s.ly doesn't exist.", filename) end
     set_local_option('input-file', input_file)

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -150,11 +150,9 @@ function process_lilypond_code()
     set_local_option('line-width', extract_unit(get_local_option('line-width')))
     process_extra_margins()
     set_local_option('output', hash_output_filename())
-    local new_score = not is_compiled()
-    if new_score then
-        compile_lilypond_fragment()
-    end
-    write_tex(new_score)
+    local do_compile = not is_compiled()
+    if do_compile then compile_lilypond_fragment() end
+    write_tex(do_compile)
 end
 
 
@@ -450,7 +448,7 @@ function newpage_if_fullpage()
     if get_local_option('fullpage') then tex.sprint([[\newpage]]) end
 end
 
-function write_tex(new_score)
+function write_tex(do_compile)
     local output = get_local_option('output')
     if not is_compiled() then
       tex.print(
@@ -482,7 +480,7 @@ function write_tex(new_score)
         --[[ Fragment, use -systems.tex file]]
         local content = systems_file:read("*all")
         systems_file:close()
-        if new_score then
+        if do_compile then
             --[[ new compilation, calculate protrusion
                  and update -systems.tex file]]
             local protrusion = calc_protrusion()

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -95,7 +95,8 @@ function write_to_filelist(filename)
     f:close()
 end
 
-function hash_output_filename(ly_code, line_width, staffsize)
+function hash_output_filename(ly_code, staffsize)
+    local line_width = get_local_option('line-width')
     local fullpage = get_local_option('fullpage')
     local evenodd = ''
     local etm = 0
@@ -136,14 +137,14 @@ end
 
 
 function process_lilypond_code(ly_code)
-    local line_width = extract_unit(get_local_option('line-width'))
     local staffsize = calc_staffsize(get_local_option('staffsize'))
+    set_local_option('line-width', extract_unit(get_local_option('line-width')))
     process_extra_margins()
-    local output = hash_output_filename(ly_code, line_width, staffsize)
+    local output = hash_output_filename(ly_code, staffsize)
     local new_score = not is_compiled(output)
     if new_score then
         compile_lilypond_fragment(
-            ly_code, staffsize, line_width, output
+            ly_code, staffsize, output
         )
     end
     write_tex(output, new_score)
@@ -187,8 +188,8 @@ function run_lilypond(ly_code, output)
 end
 
 function compile_lilypond_fragment(
-        ly_code, staffsize, line_width, output)
-    ly_code = lilypond_fragment_header(staffsize, line_width)..'\n'..ly_code
+        ly_code, staffsize, output)
+    ly_code = lilypond_fragment_header(staffsize)..'\n'..ly_code
     run_lilypond(ly_code, output)
 end
 
@@ -286,7 +287,8 @@ function calc_margins(staffsize)
     end
 end
 
-function lilypond_fragment_header(staffsize, line_width)
+function lilypond_fragment_header(staffsize)
+    local line_width = get_local_option('line-width')
     local fullpage = get_local_option('fullpage')
     local header = [[
 %%File header

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -89,8 +89,7 @@ function extract_includepaths(includepaths)
 end
 
 function write_to_filelist(filename)
-    local input_file = get_local_option('input-file')
-    if not input_file then input_file = '' end
+    local input_file = get_local_option('input-file', '')
     local f = io.open(FILELIST, 'a')
     f:write(filename, '\t', input_file, '\n')
     f:close()
@@ -533,11 +532,13 @@ function set_default_options()
 end
 
 
-function get_local_option(name)
+function get_local_option(name, default)
     if LOCAL_OPTIONS[name] then
         return LOCAL_OPTIONS[name]
-    else
+    elseif OPTIONS[name] then
         return OPTIONS[name]
+    elseif default then
+        return default
     end
 end
 

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -154,9 +154,9 @@ function lilypond_fragment(ly_code)
 end
 
 
-function lilypond_file(input_file, currfiledir)
+function lilypond_file(input_file)
     filename = splitext(input_file, 'ly')
-    input_file = currfiledir..filename..'.ly'
+    input_file = CURRENTDIR..filename..'.ly'
     if not lfs.isfile(input_file) then input_file = kpse.find_file(filename..'.ly') end
     if not lfs.isfile(input_file) then err("File %s.ly doesn't exist.", filename) end
     local i = io.open(input_file, 'r')

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -13,7 +13,7 @@
 \RequirePackage{metalogo}
 \newcommand{\lyluatex}{\textit{ly}\LuaTeX}
 
-\directlua{CURRENTDIR = '\currfiledir'}
+\directlua{CURFILEDIR = '\currfiledir'}
 % Options
 \catcode`-=11
 \directlua{

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -13,6 +13,7 @@
 \RequirePackage{metalogo}
 \newcommand{\lyluatex}{\textit{ly}\LuaTeX}
 
+\directlua{CURRENTDIR = '\currfiledir'}
 % Options
 \catcode`-=11
 \directlua{
@@ -162,12 +163,7 @@
 \directlua{newpage_if_fullpage()}
 \calcdimensions
 \currentfonts
-\directlua{
-    lilypond_file(
-        "\luatexluaescapestring{#1}",
-        "\luatexluaescapestring{\currfiledir}"
-    )%
-}%
+\directlua{lilypond_file("\luatexluaescapestring{#1}")}%
 \directlua{reset_local_options()}%
 }
 


### PR DESCRIPTION
This commit (hopefully) streamlines the program flow in the Lua part by not having arguments flow through the function calls (partially they even changed their names during this flow).

Basically the program flow is now like this:

* `lilypond_file()` and `lilypond_fragment()`
These are the entry functions and produce the content LilyPond code from the LaTeX input
* `process_lilypond_code()`
    * First all options are calculated that are needed to determine if the score has to be recompiled.
    * If necessary, `apply_lilypond_header()` is called to set up the Lilypond file/code and `run_lilypond()` to actually compile it
* finally the LaTeX code is generated

Everything that can be considered a "property" of the current score is not passed along as arguments anymore but stored as local options. *Some* values are passed as arguments, and this indicates that they are current values needed to process, not properties of the score.
This may increase the number of calls to `get_local_option()` but I'm sure the clarified flow is more than worth that cost.

This also means that there are *no* ingoing arguments into `hash_output_filename()`, which should be a good base for reworking that function.