### PR TITLE
Take "showfailed" option into account

### DIFF
--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -438,7 +438,7 @@ function Score:run_lilypond()
 end
 
 function Score:write_tex(do_compile)
-    if not self:is_compiled() then
+    if do_compile and not self:is_compiled() then
       tex.sprint(
           [[
           \begin{quote}

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -197,6 +197,25 @@ function Score:calc_properties()
     self.output = self:output_filename()
 end
 
+function Score:check_failed_compilation()
+    if not self:is_compiled() then
+        if self.showfailed == 'true' then
+            tex.sprint(
+                [[
+                \begin{quote}
+                \fbox{Score failed to compile}
+                \end{quote}
+
+                ]]
+            )
+        else
+            err("\nScore failed to compile, please check LilyPond input.\n")
+        end
+        --[[ ensure the score gets recompiled next time --]]
+        os.remove(self.output..'-systems.tex')
+    end
+end
+
 function Score:check_properties()
     for k, _ in orderedpairs(OPTIONS) do
         if not contains(OPTIONS[k], self[k]) and OPTIONS[k][2] then
@@ -435,25 +454,6 @@ function Score:run_lilypond()
     local p = io.popen(cmd, 'w')
     p:write(self.ly_code)
     p:close()
-end
-
-function Score:check_failed_compilation()
-    if not self:is_compiled() then
-        if self.showfailed == 'true' then
-            tex.sprint(
-                [[
-                \begin{quote}
-                \fbox{Score failed to compile}
-                \end{quote}
-
-                ]]
-            )
-        else
-            err("\nScore failed to compile, please check LilyPond input.\n")
-        end
-        --[[ ensure the score gets recompiled next time --]]
-        os.remove(self.output..'-systems.tex')
-    end
 end
 
 function Score:write_tex(do_compile)

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -199,7 +199,7 @@ end
 
 function Score:check_failed_compilation()
     if not self:is_compiled() then
-        if self.showfailed == 'true' then
+        if self.showfailed then
             tex.sprint(
                 [[
                 \begin{quote}

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -439,15 +439,18 @@ end
 
 function Score:write_tex(do_compile)
     if do_compile and not self:is_compiled() then
-      tex.sprint(
-          [[
-          \begin{quote}
-          \fbox{Score failed to compile}
-          \end{quote}
+        if self.showfailed == 'true' then
+            tex.sprint(
+                [[
+                \begin{quote}
+                \fbox{Score failed to compile}
+                \end{quote}
 
-          ]]
-      )
-        err("\nScore failed to compile, please check LilyPond input.\n")
+                ]]
+            )
+        else
+            err("\nScore failed to compile, please check LilyPond input.\n")
+        end
         --[[ ensure the score gets recompiled next time --]]
         os.remove(self.output..'-systems.tex')
     end

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -437,8 +437,8 @@ function Score:run_lilypond()
     p:close()
 end
 
-function Score:write_tex(do_compile)
-    if do_compile and not self:is_compiled() then
+function Score:check_failed_compilation()
+    if not self:is_compiled() then
         if self.showfailed == 'true' then
             tex.sprint(
                 [[
@@ -454,6 +454,10 @@ function Score:write_tex(do_compile)
         --[[ ensure the score gets recompiled next time --]]
         os.remove(self.output..'-systems.tex')
     end
+end
+
+function Score:write_tex(do_compile)
+    if do_compile then self:check_failed_compilation() end
     --[[ Now we know there is a proper score --]]
     if self.fullpagestyle == 'default' then
         if self['print-page-number'] then

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -33,7 +33,7 @@
     ['pass-fonts'] = {'true', 'false'},
     ['print-page-number'] = {'false', 'true'},
     ['program'] = {'lilypond'},
-    ['showfailed'] = {'true', 'false'},
+    ['showfailed'] = {'false', 'true'},
     ['staffsize'] = {'0', ly.is_dim},
     ['tmpdir'] = {'tmp_ly'},
   })


### PR DESCRIPTION
For some reason the "showfailed" option has been forgotten recently.

The behaviour when a to-be-compiled score failed is now:

`showfailed == false`: Produce an error, but print nothing
`showfailed == true`: print the box, but don't produce an error

In addition I changed the default to false