### PR TITLE
Debug lilypond and better handling of lilypond failure

### DIFF
--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -372,6 +372,29 @@ function Score:lilypond_cmd()
     return cmd.."-o "..self.output.." "..input, mode
 end
 
+function Score:lilypond_version()
+    print("\nCompiling Score with LilyPond executable '"..self.program.."' ...")
+    local p = io.popen(self.program..' --version', 'r')
+    if not p then
+      err([[
+      LilyPond could not be started.
+      Please check that LuaLaTeX is
+      started with the --shell-escape option.
+      ]])
+    end
+    local result = p:read()
+    p:close()
+    if result and result:match('GNU LilyPond') then
+        print(result)
+    else
+        err([[
+        LilyPond could not be started.
+        Please check that 'program' points
+        to a valid LilyPond executable
+        ]])
+    end
+end
+
 function Score:margins()
     local tex_top = self['extra-top-margin'] + convert_unit((
         tex.sp('1in') + tex.dimen.voffset + tex.dimen.topmargin +
@@ -480,15 +503,8 @@ end
 
 function Score:run_lilypond()
     mkdirs(dirname(self.output))
-    print("\nCompiling Score with LilyPond executable '"..self.program.."' ...")
+    self:lilypond_version()
     local p = io.popen(self:lilypond_cmd())
-    if not p then
-        err([[
-        LilyPond could not be started.
-        Please check that LuaLaTeX is
-        started with the --shell-escape option.
-        ]])
-    end
     if self.debug then
         local f = io.open(self.output..".log", 'w')
         f:write(p:read('*a'))

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -238,6 +238,15 @@ function Score:check_properties()
     end
 end
 
+function Score:debug_lilypond()
+    if self['debug-lilypond'] then
+        local name = self.output..'.ly'
+        local f = io.open(self.output..'.ly', 'w')
+        f:write(self.ly_code)
+        f:close()
+    end
+end
+
 function Score:delete_intermediate_files()
   local i = io.open(self.output..'-systems.count', 'r')
   if i then
@@ -250,6 +259,9 @@ function Score:delete_intermediate_files()
       os.remove(self.output..'-systems.texi')
       os.remove(self.output..'.eps')
       os.remove(self.output..'.pdf')
+      if not self['debug-lilypond'] then
+          os.remove(self.output..'.ly')
+      end
   end
 end
 
@@ -427,6 +439,7 @@ function Score:process()
     local do_compile = not self:is_compiled()
     if do_compile then
         self.ly_code = self:header()..self.ly_code
+        self:debug_lilypond()
         self:run_lilypond()
     end
     self:write_tex(do_compile)

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -238,9 +238,6 @@ function Score:check_properties()
     end
 end
 
-function Score:debug_lilypond()
-end
-
 function Score:delete_intermediate_files()
   local i = io.open(self.output..'-systems.count', 'r')
   if i then

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -474,7 +474,13 @@ function Score:run_lilypond()
     cmd = cmd.."-o "..self.output.." "..self.output..".ly"
     print("\nCompiling Score with LilyPond executable '"..self.program.."' ...")
     local exit = os.execute(cmd.." > "..self.output..".log 2>&1")
-    if exit ~= 0 then
+    if not exit then
+        err([[
+        LilyPond could not be started.
+        Please check that LuaLaTeX is
+        started with the --shell-escape option.
+        ]])
+    elseif exit ~= 0 then
         warn([[
         LilyPond reported a failed compilation,
         but this does not necessarily mean that

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -20,7 +20,7 @@
   ly.declare_package_options({
     ['cleantmp'] = {'false', 'true', ''},
     ['current-font-as-main'] = {'true', 'false', ''},
-    ['debug-lilypond'] = {'false', 'true', ''},
+    ['debug'] = {'false', 'true', ''},
     ['extra-bottom-margin'] = {'0', ly.is_dim},
     ['extra-top-margin'] = {'0', ly.is_dim},
     ['fullpagealign'] = {'staffline', 'crop'},

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -20,6 +20,7 @@
   ly.declare_package_options({
     ['cleantmp'] = {'false', 'true', ''},
     ['current-font-as-main'] = {'true', 'false', ''},
+    ['debug-lilypond'] = {'false', 'true', ''},
     ['extra-bottom-margin'] = {'0', ly.is_dim},
     ['extra-top-margin'] = {'0', ly.is_dim},
     ['fullpagealign'] = {'staffline', 'crop'},


### PR DESCRIPTION
This PR includes two features:

* a `debug-lilypond` option that will save both LilyPond's log and the generated LilyPond code in `<output>.ly` and `<output>.log`
* When LilyPond exits with non-zero status a warning is issued, pointing to the log and the .ly file, which are then kept, regardless of the value of `debug-lilypond`.

**Note:** I assume this doesn't work on Windows, but I didn't find a solution for that. (If that's true then it would probably prevent *any* Lilypond call)