### PR TITLE
Better handling of compilation failure warnings

### DIFF
--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -224,7 +224,35 @@ function Score:calc_properties()
 end
 
 function Score:check_failed_compilation()
-    if not self:is_compiled() then
+    local debug_msg
+    if self.debug then
+        debug_msg = string.format([[
+        Please check the log file
+        %s
+        and the generated LilyPond code
+        %s
+        ]],
+        self.output..'.log',
+        self.output..'.ly')
+    else
+        debug_msg = [[
+        If you need more information
+        than the above message,
+        please retry with option debug=true.
+        ]]
+    end
+    if self:is_compiled() then
+        if self.lilypond_error then
+            warn([[
+            LilyPond reported a failed compilation
+            but produced a score.
+            %s
+            ]],
+            debug_msg
+            )
+        end
+        return true
+    else
         --[[ ensure the score gets recompiled next time --]]
         self:delete_intermediate_files()
         if self.showfailed then
@@ -237,12 +265,19 @@ function Score:check_failed_compilation()
 
                 ]]
             )
+            warn([[
+        LilyPond failed to compile the score.
+%s
+            ]],
+            debug_msg)
             return false
         else
-            err("\nScore failed to compile, please check LilyPond input.\n")
+            err([[
+        Score failed to compile the score.
+%s
+            ]],
+          debug_msg)
         end
-    else
-        return true
     end
 end
 
@@ -543,36 +578,15 @@ function Score:run_lilypond()
     mkdirs(dirname(self.output))
     self:lilypond_version()
     local p = io.popen(self:lilypond_cmd())
+    local debug_msg
     if self.debug then
         local f = io.open(self.output..".log", 'w')
         f:write(p:read('*a'))
         f:close()
-        self.lilypond_error = not p:close()
-        if self.lilypond_error then
-            warn([[
-            LilyPond reported a failed compilation,
-            but this does not necessarily mean that
-            no score has been produced.
-            Please check the log file
-            %s
-            and the generated LilyPond code
-            %s
-            ]],
-            self.output..'.log',
-            self.output..'.ly')
-        end
     else
         p:write(self.ly_code)
-        self.lilypond_error = not p:close()
-        if self.lilypond_error then
-            warn([[
-            LilyPond reported a failed compilation;
-            if you need more information
-            than the above message,
-            please retry with option debug=true.
-            ]])
-        end
     end
+    self.lilypond_error = not p:close()
 end
 
 function Score:write_tex(do_compile)


### PR DESCRIPTION
Follow-up to #77 (but slightly to involved to push directly to master)

With this commit only *one* warning/error is produced,
depending on whether an actual score has been generated or not.
'debug' and 'showfailed' options should work in any combination.

The compilation checks are now concentrated in one function,
un-cluttering run_lilypond() again.