### PR TITLE
Discussion: Ignore pdf/eps/ps files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,9 @@ ctan
 *.dvi
 *-converted-to.*
 # these rules might exclude image files for figures etc.
-# *.ps
-# *.eps
-# *.pdf
+*.ps
+*.eps
+*.pdf
 
 ## Bibliography auxiliary files (bibtex/biblatex/biber):
 *.bbl


### PR DESCRIPTION
PDF, EPS, PS have been commented out in the .gitignore file because they
"might exclude image files for figures".

However, I suggest ignoring them and adding files explicitly if they are
needed for figures etc.