### PR TITLE
Discuss: By default don't pass fonts to LilyPond

### DIFF
--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -32,7 +32,7 @@
     ['line-width'] = {'', ly.is_dim},
     ['paperwidth'] = {'', ly.is_dim},
     ['paperheight'] = {'', ly.is_dim},
-    ['pass-fonts'] = {'true', 'false', ''},
+    ['pass-fonts'] = {'false', 'true', ''},
     ['print-page-number'] = {'false', 'true', ''},
     ['program'] = {'lilypond'},
     ['ragged-right'] = {'default', 'true', 'false', ''},


### PR DESCRIPTION
When the .tex document uses TeX-fonts (i.e. fonts installed in the
texmf tree and not as system fonts passing the text document's fonts to LilyPond will result in the use of ugly fallback fonts. This is usually the case
when the user creates a simple document without explicit font settings.

When weighing between not activating a cool lyluatex feature by default
or risking ugly unexpected results I think we should opt for the less interesting
default.