### PR TITLE
WIP: verbatim

### DIFF
--- a/examples/verbatim.tex
+++ b/examples/verbatim.tex
@@ -1,0 +1,38 @@
+\documentclass{scrartcl}
+\usepackage{libertine}
+\usepackage[verbatim,
+intertext={The “intertext” option can be used to print some text between the code and the score}]{lyluatex}
+\begin{document}
+
+\section*{Print LilyPond code}
+
+The \texttt{verbatim} option causes the LilyPond code to be printed before the score.  The current issue is that the content of \texttt{\textbackslash lilypond} and the \texttt{lilypond} environment are passed as one line.
+
+\lilypond[intertext=]{ c d e d }
+
+\hrule
+
+\textbf{NOTE:} The local \texttt{intertext} option doesn't work properly yet: it will only work when set to an empty string or to a single word. Setting it to a string enclosed in curly braces or quotation marks will make the option ignored.
+
+\begin{lilypond}[intertext={This change of content does not have any effect}]
+{
+c d e d
+}
+\end{lilypond}
+
+\hrule
+
+\medskip
+\renewcommand{\lyIntertext}[1]{
+
+\textcolor{magenta}{#1}
+
+\bigskip
+}
+The contents of included \emph{files} already work properly:
+
+\lysetoption{intertext}{The formatting of the intertext be adjusted by renewing the command “lyIntertext”}
+
+\lilypondfile[intertext={This change of content does not have any effect}]{../ly/Sphinx/Sphinx}
+
+\end{document}

--- a/ly/Sphinx/Sphinx.ly
+++ b/ly/Sphinx/Sphinx.ly
@@ -1,0 +1,13 @@
+\version "2.18.2"
+
+\header {
+  title = "Sphinxes. No. 1"
+}
+
+{
+  \time 4/2
+  \clef bass
+  as,\breve
+  c
+  b,
+}

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -206,6 +206,7 @@ function Score:new(ly_code, options, input_file)
 end
 
 function Score:calc_properties()
+    self:calc_verbatim()
     -- staff display
     -- handle meta properties
     if self.notime then
@@ -351,6 +352,18 @@ LilyPond failed to compile the score.
     end
 end
 
+function Score:calc_verbatim()
+    if self.verbatim then
+        self.verbatim = string.format([[
+\begin{verbatim}
+%s
+  \end{verbatim}
+        ]],
+        self.ly_code)
+    else self.verbatim = ''
+    end
+end
+
 function Score:check_properties()
     local unexpected = false
     for k, _ in orderedpairs(OPTIONS) do
@@ -370,15 +383,6 @@ function Score:check_properties()
                 self[k], k, table.concat(OPTIONS[k], ', ')
             )
         end
-    end
-    if self.verbatim then
-        self.verbatim = string.format([[
-\begin{verbatim}
-%s
-\end{verbatim}
-        ]],
-        self.ly_code)
-    else self.verbatim = ''
     end
 end
 
@@ -685,7 +689,7 @@ function Score:write_tex(do_compile)
     if do_compile then
         if not self:check_failed_compilation() then return end
     end
-    if self.verbatim ~= '' then tex.sprint(self.verbatim) end
+    if self.verbatim ~= '' then tex.print(self.verbatim:explode('\n')) end
     --[[ Now we know there is a proper score --]]
     if self.fullpagestyle == '' then
         if self['print-page-number'] then

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -374,8 +374,8 @@ function Score:calc_verbatim()
   \end{verbatim}
 %s
         ]],
-        self.ly_code:gsub('.*%% begin verbatim', ''):gsub(
-            '%% end verbatim.*', ''),
+        self.ly_code:gsub('.*%%%s*begin verbatim', ''):gsub(
+            '%%%s*end verbatim.*', ''),
         intertext)
     else self.verbatim = ''
     end

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -374,7 +374,8 @@ function Score:calc_verbatim()
   \end{verbatim}
 %s
         ]],
-        self.ly_code,
+        self.ly_code:gsub('.*%% begin verbatim', ''):gsub(
+            '%% end verbatim.*', ''),
         intertext)
     else self.verbatim = ''
     end

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -371,6 +371,15 @@ function Score:check_properties()
             )
         end
     end
+    if self.verbatim then
+        self.verbatim = string.format([[
+\begin{verbatim}
+%s
+\end{verbatim}
+        ]],
+        self.ly_code)
+    else self.verbatim = ''
+    end
 end
 
 function Score:content()
@@ -676,6 +685,7 @@ function Score:write_tex(do_compile)
     if do_compile then
         if not self:check_failed_compilation() then return end
     end
+    if self.verbatim ~= '' then tex.sprint(self.verbatim) end
     --[[ Now we know there is a proper score --]]
     if self.fullpagestyle == '' then
         if self['print-page-number'] then

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -353,13 +353,22 @@ LilyPond failed to compile the score.
 end
 
 function Score:calc_verbatim()
+    local intertext = ''
     if self.verbatim then
+        if self.intertext ~= '' then
+            intertext = string.format([[
+\lyIntertext{%s}
+            ]],
+            self.intertext)
+        end
         self.verbatim = string.format([[
 \begin{verbatim}
 %s
   \end{verbatim}
+%s
         ]],
-        self.ly_code)
+        self.ly_code,
+        intertext)
     else self.verbatim = ''
     end
 end

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -518,9 +518,6 @@ function Score:lilypond_cmd()
     for _, dir in ipairs(extract_includepaths(self.includepaths)) do
         cmd = cmd.."-I "..dir:gsub('^./', lfs.currentdir()..'/').." "
     end
-    print("")
-    print("Generated command")
-    print(cmd)
     return cmd.."-o "..self.output.." "..input, mode
 end
 

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -47,6 +47,7 @@
     ['showfailed'] = {'false', 'true' ,''},
     ['staffsize'] = {'0', ly.is_dim},
     ['tmpdir'] = {'tmp_ly'},
+    ['verbatim'] = {'false', 'true', ''},
   })
 }
 \directlua{

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -14,6 +14,13 @@
 \RequirePackage{metalogo}
 \newcommand{\lyluatex}{\textit{ly}\LuaTeX}
 
+\newcommand{\lyIntertext}[1]{%
+
+#1
+
+\bigskip
+}
+
 % Options
 \catcode`-=11
 \directlua{
@@ -28,6 +35,7 @@
     ['fullpagestyle'] = {''},
     ['includepaths'] = {'./'},
     ['insert'] = {'systems', 'fullpage', 'inline'},
+    ['intertext'] = {''},
     ['labelprefix'] = {'ly_'},
     ['line-width'] = {'', ly.is_dim},
     ['noclef'] = {'false', 'true', ''},


### PR DESCRIPTION
Intends to close #91 

When verbatim is set, print the ly_code as a verbatim block before the score.

**NOTE/QUESTION:**
input from fragments is printed on *one* line, linebreaks are suppressed.
It seems this is already the case when `\BODY` is passed from `ly@compilely`.

@jperon is there a way to pass the content of `lilypond` command/environment into Lua while preserving the newlines?

