### PR TITLE
Protect options in \lysetoption

### DIFF
--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -83,7 +83,7 @@
 
 % Command to change options during the document
 \newcommand{\lysetoption}[2]{%
-  \directlua{ly.set_property('#1', '#2')}
+  \directlua{ly.set_property([[#1]], [[#2]])}
 }
 
 % Line width is calculated if set to 'default'


### PR DESCRIPTION
I found that protecting the option values this way allows to write
```tex
    \lysetoption{line-width}{0.8\linewidth}
```
which will make it possible to use that as a "percentage" replacement (#103). (It is already possible to use `0.8\linewidth` as a package or local option (of course raising an error later when trying to calculate a value).)

Please have a careful look if I didn't misunderstand anything and missed any side-effects this change might have.