### PR TITLE
Fix obsolete comment

### DIFF
--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -98,7 +98,7 @@
 % Command to change the appearance of verbatim 'intertext'
 \newcommand{\lyIntertext}[1]{\noindent #1}
 
-% Line width is calculated if set to 'default'
+% Retrieve the current page number fir use in the functions
 \def\ly@page{\directlua{ly.PAGE = \thepage}}
 
 % Retrieve the three main font families (rm, sf, tt)

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -98,7 +98,7 @@
 % Command to change the appearance of verbatim 'intertext'
 \newcommand{\lyIntertext}[1]{\noindent #1}
 
-% Retrieve the current page number fir use in the functions
+% Retrieve the current page number for use in the functions
 \def\ly@page{\directlua{ly.PAGE = \thepage}}
 
 % Retrieve the three main font families (rm, sf, tt)


### PR DESCRIPTION
This comment was a leftover from a previous state.

Additional question: is it necessary to do that in the TeX Part?  it seems cleaner to ask for that value directly from Lua, if that's possible.