### PR TITLE
Add 'twoside' option

### DIFF
--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -613,10 +613,7 @@ function Score:ly_raggedright()
 end
 
 function Score:ly_twoside()
-    if self.twoside == 'default' then return ly.TWOSIDE
-    elseif self.twoside then return 't'
-    else return 'f'
-    end
+    if self.twoside then return 't' else return 'f' end
 end
 
 function Score:margins()

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -42,7 +42,7 @@ local LY_HEAD = [[
 }
 \paper{
     <<<PAPER>>>
-    two-sided = ##t
+    two-sided = ##<<<TWOSIDE>>>
     line-width = <<<LINEWIDTH>>>\pt
     <<<INDENT>>>
     <<<RAGGEDRIGHT>>>
@@ -301,6 +301,7 @@ function Score:calc_properties()
     if self['current-font-as-main'] then
         self.rmfamily = self['current-font']
     end
+    self.twoside = self:ly_twoside()
     -- temporary file name
     self.output = self:output_filename()
 end
@@ -506,7 +507,8 @@ function Score:header()
         [[<<<INDENT>>>]], self:ly_indent()):gsub(
         [[<<<RAGGEDRIGHT>>>]], self:ly_raggedright()):gsub(
         [[<<<FONTS>>>]], self:fonts()):gsub(
-        [[<<<STAFFPROPS>>>]], self.staff_props)
+        [[<<<STAFFPROPS>>>]], self.staff_props):gsub(
+        [[<<<TWOSIDE>>>]], self.twoside)
     if self.insert == 'fullpage' then
         local ppn = 'f'
         if self['print-page-number'] then ppn = 't' end
@@ -610,6 +612,13 @@ function Score:ly_raggedright()
     end
 end
 
+function Score:ly_twoside()
+    if self.twoside == 'default' then return ly.TWOSIDE
+    elseif self.twoside then return 't'
+    else return 'f'
+    end
+end
+
 function Score:margins()
     local tex_top = self['extra-top-margin'] + convert_unit((
         tex.sp('1in') + tex.dimen.voffset + tex.dimen.topmargin +
@@ -629,8 +638,9 @@ function Score:margins()
             top-margin = %s\pt
             bottom-margin = %s\pt
             inner-margin = %s\pt
+            left-margin = %s\pt
             ]],
-            tex_top, tex_bottom, inner
+            tex_top, tex_bottom, inner, inner
         )
     elseif self.fullpagealign == 'staffline' then
       local top_distance = 4 * tex_top / self.staffsize + 2
@@ -639,6 +649,7 @@ function Score:margins()
         top-margin = 0\pt
         bottom-margin = 0\pt
         inner-margin = %s\pt
+        left-margin = %s\pt
         top-system-spacing =
         #'((basic-distance . %s)
            (minimum-distance . %s)
@@ -655,6 +666,7 @@ function Score:margins()
            (padding . 0)
            (stretchability . 0))
         ]],
+        inner,
         inner,
         top_distance,
         top_distance,

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -13,6 +13,9 @@
 
 \RequirePackage{metalogo}
 \newcommand{\lyluatex}{\textit{ly}\LuaTeX}
+
+\edef\ly@false{false}\def\ly@istwosided{\if@twoside\else\ly@false\fi}
+
 % Options
 \catcode`-=11
 \directlua{
@@ -53,7 +56,7 @@
     ['showfailed'] = {'false', 'true' ,''},
     ['staffsize'] = {'0', ly.is_dim},
     ['tmpdir'] = {'tmp_ly'},
-    ['twoside'] = {'default', 'false', 'true', ''},
+    ['twoside'] = {'\ly@istwosided', 'false', 'true', ''},
     ['verbatim'] = {'false', 'true', ''},
     % MusicXML options
     ['absolute'] = {'false', 'true', ''},
@@ -74,14 +77,6 @@
   end
 }
 \catcode`-=12
-
-\makeatletter
-\if@twoside%
-\directlua{ly.TWOSIDE = "t"}
-\else
-\directlua{ly.TWOSIDE = "f"}
-\fi
-%\makeatother
 
 %\directlua{ly.TWOSIDE = 'f'}
 
@@ -135,6 +130,7 @@
 \ly@setunits%
 \directlua{
   ly.CURRFILEDIR = '\currfiledir'
+  ly.set_property('twoside', '\ly@istwosided')
   #1
   ly.newpage_if_fullpage()
 }

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -53,6 +53,7 @@
     ['showfailed'] = {'false', 'true' ,''},
     ['staffsize'] = {'0', ly.is_dim},
     ['tmpdir'] = {'tmp_ly'},
+    ['twoside'] = {'default', 'false', 'true', ''},
     ['verbatim'] = {'false', 'true', ''},
     % MusicXML options
     ['absolute'] = {'false', 'true', ''},
@@ -73,6 +74,16 @@
   end
 }
 \catcode`-=12
+
+\makeatletter
+\if@twoside%
+\directlua{ly.TWOSIDE = "t"}
+\else
+\directlua{ly.TWOSIDE = "f"}
+\fi
+%\makeatother
+
+%\directlua{ly.TWOSIDE = 'f'}
 
 \newcommand{\ly@setunits}{%
   \let\ly@old@in\in\protected\def\in{in}%


### PR DESCRIPTION
Closes #119

When the 'twoside' option is not set (or reset to 'default') full-page scores will inherit the one/twoside option from the .tex document.
When set to either false or true that value is used regardles of the text document's setting.

One special thing had to be considered is LilyPond's behaviour to respect 'inner-margin' only in two-side, 'left-margin' only in one-side mode. The solution was to specify both as equal.

It *may* be desirable to clean that up a bit and write the full code depending on the twoside option instead of only replacing the 't' or 'f'.