### PR TITLE
Refactor - fix #116

### DIFF
--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -141,7 +141,7 @@ local function locate(file, includepaths, ext)
         end
     end
     if not lfs.isfile(result) then result = kpse.find_file(file) end
-    if not result and ext and file:match('.%w+$') ~= ext then return locate(file..ext, includepaths) end
+    if not result and ext and file:match('%.[^%.]+$') ~= ext then return locate(file..ext, includepaths) end
     return result
 end
 

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -224,7 +224,7 @@ function latex.filename(printfilename, insert, input_file)
 end
 
 function latex.fullpagestyle(style, ppn)
-    local function texoutput(s) return '\\includepdfset{pagecommand='..s..'}' end
+    local function texoutput(s) tex.print('\\includepdfset{pagecommand='..s..'}') end
     if style == '' then
         if ppn then
             texoutput('\\thispagestyle{empty}')

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -327,11 +327,7 @@ function Score:calc_properties()
         ]]
     else self.l_staff = ''
     end
-    self.staff_props = string.format([[
-    %s
-    %s
-    %s
-    %s
+    self.staff_props = string.format([[%s%s%s%s
     ]],
     self.l_clef,
     self.l_timing,

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -290,50 +290,7 @@ function Score:new(ly_code, options, input_file)
 end
 
 function Score:calc_properties()
-    -- staff display
-    -- handle meta properties
-    if self.notime then
-        self.notimesig = 'true'
-        self.notiming = 'true'
-    end
-    if self.nostaff then
-        self.nostaffsymbol = 'true'
-        self.notimesig = 'true'
-        -- do *not* suppress timing
-        self.noclef = 'true'
-    end
-    -- set templates
-    if self.noclef then
-        self.l_clef = [[
-            \context { \Staff \remove "Clef_engraver" }
-        ]]
-    else self.l_clef = ''
-    end
-    if self.notiming then
-        self.l_timing = [[
-            \context { \Score timing = ##f }
-        ]]
-    else self.l_timing = ''
-    end
-    if self.notimesig then
-        self.l_timesig = [[
-            \context { \Staff \remove "Time_signature_engraver" }
-        ]]
-    else self.l_timesig = ''
-    end
-    if self.nostaffsymbol then
-        self.l_staff = [[
-            \context { \Staff \remove "Staff_symbol_engraver" }
-        ]]
-    else self.l_staff = ''
-    end
-    self.staff_props = string.format([[%s%s%s%s
-    ]],
-    self.l_clef,
-    self.l_timing,
-    self.l_timesig,
-    self.l_staff
-    )
+    self:calc_staff_properties()
     -- relative
     if self.relative then
         if self.relative == '' then
@@ -363,6 +320,53 @@ function Score:calc_properties()
     self.twoside = self:ly_twoside()
     -- temporary file name
     self.output = self:output_filename()
+end
+
+function Score:calc_staff_properties()
+    -- handle meta properties
+    if self.notime then
+        self.notimesig = 'true'
+        self.notiming = 'true'
+    end
+    if self.nostaff then
+        self.nostaffsymbol = 'true'
+        self.notimesig = 'true'
+        -- do *not* suppress timing
+        self.noclef = 'true'
+    end
+    -- set templates
+    local clef, timing, timesig, staff
+    if self.noclef then
+        clef = [[
+            \context { \Staff \remove "Clef_engraver" }
+        ]]
+    else clef = ''
+    end
+    if self.notiming then
+        timing = [[
+            \context { \Score timing = ##f }
+        ]]
+    else timing = ''
+    end
+    if self.notimesig then
+        timesig = [[
+            \context { \Staff \remove "Time_signature_engraver" }
+        ]]
+    else timesig = ''
+    end
+    if self.nostaffsymbol then
+        staff = [[
+            \context { \Staff \remove "Staff_symbol_engraver" }
+        ]]
+    else staff = ''
+    end
+    self.staff_props = string.format([[%s%s%s%s
+    ]],
+    clef,
+    timing,
+    timesig,
+    staff
+    )
 end
 
 function Score:check_properties()

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -18,6 +18,7 @@
 \directlua{
   ly = require(kpse.find_file("lyluatex.lua"))
   ly.declare_package_options({
+    ['addversion'] = {'false', 'true', ''},
     ['cleantmp'] = {'false', 'true', ''},
     ['current-font-as-main'] = {'true', 'false', ''},
     ['debug'] = {'false', 'true', ''},
@@ -94,11 +95,14 @@
   \directlua{ly.set_property([[#1]], [[#2]])}
 }
 
-% This macro defines how the filename of a score will look like if printed.
+% How the filename of a score will look like (if printed)
 \newcommand{\lyFilename}[1]{\noindent #1\par\bigskip}
 
-% Command to change the appearance of verbatim 'intertext'
+% Appearance of verbatim 'intertext' (if printed)
 \newcommand{\lyIntertext}[1]{\noindent #1\par\bigskip}
+
+% Appearance of LilyPond version (if printed)
+\newcommand{\lyVersion}[1]{\noindent {\footnotesize\emph{(GNU LilyPond #1)}\par}\bigskip}
 
 % Retrieve the current page number for use in the functions
 \def\ly@page{\directlua{ly.PAGE = \thepage}}

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -47,6 +47,8 @@
     ['print-page-number'] = {'false', 'true', ''},
     ['printfilename'] = {'false', 'true', ''},
     ['program'] = {'lilypond'},
+    ['protrusion'] = {'', ly.is_dim},
+    ['noprotrusion'] = {'default', ly.is_neg},
     ['ragged-right'] = {'default', 'true', 'false', ''},
     ['noragged-right'] = {'default', ly.is_neg},
     ['relative'] = {'false', ly.is_num},

--- a/test.tex
+++ b/test.tex
@@ -125,7 +125,7 @@ Ce fragment :
 
 \lilypond{a' b' c''}
 
-sera écrit plus petit en note de bas de
+\noindent sera écrit plus petit en note de bas de
 page\footnote{\lilypond[relative=2]{a b c}}.
 
 \newpage


### PR DESCRIPTION
All functions that write LaTeX code are now in a `latex` array. They need to
receive explicit arguments, so that it's clear where each score property is used.

Also fixes #124