### PR TITLE
Suppress "overfull hbox" warnings

### DIFF
--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -98,12 +98,14 @@
   \let\ly@old@pt\pt\protected\def\pt{pt}%
   \let\ly@old@mm\mm\protected\def\mm{mm}%
   \let\ly@old@cm\cm\protected\def\cm{cm}%
+  \let\ly@old@hfuzz\hfuzz\setlength{\hfuzz}{\maxdimen}
 }
 \newcommand{\ly@resetunits}{%
   \let\in\ly@old@in%
   \let\pt\ly@old@pt%
   \let\mm\ly@old@mm%
   \let\cm\ly@old@cm%
+  \setlength{\hfuzz}{\ly@old@hfuzz}
 }
 
 % Command to change options during the document


### PR DESCRIPTION
We will very often produce overfull hboxes through intended protrusion.
The way to completely suppress the warnings is to temporarily set `\hfuzz` to
a huge value.

Two questions about the approach:
* is it OK to "hijack" `\ly@setunits` for this or should it be implemented in its own macro?
* Is it OK to *completely* suppress the warning?
  I think so because we shorten a score not to be cut off at page border and if the user sets max-protrusion to be even higher they should be knowing what they do.