### PR TITLE
Raw pdf name output

### DIFF
--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -386,6 +386,12 @@ function latex.label(label, labelprefix)
     if label then tex.sprint('\\label{'..labelprefix..label..'}%%') end
 end
 
+function latex.systems_list(filename, hoffset, range)
+    tex.sprint(-hoffset..'pt,')
+    for i = 1, #range - 1 do tex.sprint(filename..'-'..range[i]..',') end
+    tex.sprint(filename..'-'..range[#range])
+end
+
 ly.verbenv = {[[\begin{verbatim}]], [[\end{verbatim}]]}
 function latex.verbatim(verbatim, ly_code, intertext, version)
     if verbatim then
@@ -1121,6 +1127,13 @@ function Score:tex_margin_top()
 end
 
 function Score:write_latex(do_compile)
+    if self['raw-pdf']
+    then
+        if self.insert == 'systems' then
+            latex.systems_list(self.output, self.protrusion, self:_range())
+        else tex.sprint(self.output) end
+        return
+    end
     latex.filename(self.printfilename, self.insert, self.input_file)
     latex.verbatim(self.verbatim, self.ly_code, self.intertext, self.addversion)
     if do_compile and not self:is_compiled_without_error() then return end

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -72,7 +72,7 @@
     ['showfailed'] = {'false', 'true' ,''},
     ['staffsize'] = {'0', ly.is_dim},
         ['inline-staffsize'] = {'0', ly.is_dim},
-    ['tmpdir'] = {'tmp_ly'},
+    ['tmpdir'] = {'tmp-ly'},
     ['twoside'] = {'\ly@istwosided', 'false', 'true', ''},
     ['verbatim'] = {'false', 'true', ''},
     ['voffset'] = {'0pt', ly.is_dim},

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -64,6 +64,7 @@
     ['program'] = {'lilypond'},
     ['protrusion'] = {'', ly.is_dim},
         ['noprotrusion'] = {'default', ly.is_neg},
+    ['raw-pdf'] = {'false', 'true', ''},
     ['quote'] = {'false', 'true', ''},
     ['ragged-right'] = {'default', 'true', 'false', ''},
         ['noragged-right'] = {'default', ly.is_neg},


### PR DESCRIPTION
This option does not return any \includegraphics macros or similar but the raw PDF name(s) (without extension).

For `insert=inline|bare-inline|fullpage` the plain filename is returned, including the tmpdir and the hash (i.e.: `self.output` of the score). 
For `insert=systems` a comma-separated list is returned, containing the file names as above but also the horizontal offset in the first element:
```
-5pt,tmp-ly/my-hash-1,tmp-ly/my-hash-5
```
(when `print-only` is set to `{1,5}` and the left protrusion is 5pt).

Open questions:

* I do currently *not* enclose the return value in braces because I think it is better to consume the plain filename string
* At this point my LaTeX fu is not sufficient to create appropriate wrapper commands. I don't know how I can create a command or environment where I can enter the lilypond code, pass it to lyluatex functions and "use" the result (e.g. by wrapping it in my own \includegraphics calls). All I managed was to print the raw output to the document (proving that the code itself works properly). It would be great if someone could add such examples to `examples/wrappingcommands.tex`

**PS:** This is based on #153 and can only be merged after that.