### PR TITLE
Better handling of suppressed indentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,10 @@ sympy-plots-for-*.tex/
 # WinEdt
 *.bak
 *.sav
+
+# LilyPond intermediate files
+*-systems.*
+*.midi
+
+# lyluatex temp directories
+*tmp-ly/

--- a/examples/dynamic-indent.tex
+++ b/examples/dynamic-indent.tex
@@ -89,7 +89,26 @@ will be automatically activated to avoid having the \emph{whole} score narrowed:
   \repeat unfold 25 { c' d' e' d' }
 \end{lilypond}
 
+\paragraph{Right protrusion}
+The dynamic handling of (automatic) indent also works correctly when there is
+protrusion handling to the right. The following score has the ties manually
+shaped to exceed the staff symbol by 10, and 7 staff spaces, and
+\texttt{max-protrusion=1cm} .
 
+\begin{lilypond}[nofragment,max-protrusion=1cm,]
+{
+  \set Staff.instrumentName = "Violin 1 & 2"
+  \set Staff.shortInstrumentName = "Vl 1 & 2"
+  \shape #'((0 . 0)(0 . 0)(3 . 0)(10 . 0)) Tie
+  c'1 ~ \break
+  \shape #'((0 . 0)(0 . 0)(3 . 0)(7 . 0)) Tie
+  c' ~ \break
+  c'
+}
+\end{lilypond}
+
+
+\paragraph{Performance considerations}
 The handling of indent suppression may require up to four compilations of the
 score, but these are handled automatically, and the resulting intermediate
 stages of the score are cached just like the scores actually used in the

--- a/examples/dynamic-indent.tex
+++ b/examples/dynamic-indent.tex
@@ -101,5 +101,16 @@ more LilyPond compilations and therefore compilation time. But it will only
 apply and be executed if the score exceeds the protrusion limit, so it can only
 occur in circumstances where multiple LilyPond runs are expected anyway.
 
+\paragraph{Known Issues:}
+If \texttt{autoindent} is implicitly set like in the following example, and
+\texttt{max-protrusion=0cm} then the indented first system doesn't correctly
+refer to the text margin (\texttt{=0cm}) but to the staff symbol of the
+surrounding systems.
+
+\begin{lilypond}[indent=1cm,print-only={3,1,2},max-protrusion=0cm]
+  \set Staff.instrumentName = "Violin"
+  \repeat unfold 25 { c' d' e' d' }
+\end{lilypond}
+
 
 \end{document}

--- a/examples/dynamic-indent.tex
+++ b/examples/dynamic-indent.tex
@@ -8,26 +8,29 @@
 This document demonstrates the use of \texttt{indent} and \texttt{autoindent},
 partially in combination with \texttt{print-only}.
 
-\texttt{indent=1cm} indents the first line, but if the resulting score contains
+\texttt{indent=2cm} indents the first line, but if the resulting score contains
 only one system this indent is suppressed (issuing a warning on the console):
 
-\begin{lilypond}[indent=1cm]
+\begin{lilypond}[indent=2cm]
+  \set Staff.instrumentName = "Violin"
   \repeat unfold 12 { c' d' e' d' }
 \end{lilypond}
 
-\begin{lilypond}[indent=1cm]
-  { c' d' e' d' }
+\begin{lilypond}[indent=2cm]
+  {
+    \set Staff.instrumentName = "Violin"
+    c' d' e' d'
+  }
 \end{lilypond}
 
-If the output of a score containing more than one system is limited to the first
-system using \texttt{print-only=1} then the indent is removed but the score is
-recompiled to ensure a full-length system. The following score is the first
-system of the first two-system score:
-
-\textbf{This is broken:} The indent should be suppressed. For
-this \emph{two} compilations would have been necessary instead of just one.
+If the output of a score which contains more than one system is limited to the
+first system using \texttt{print-only=1} then the indent is removed but the
+score is recompiled to ensure a full-length system. The following score shows
+the two-system score from above (with \texttt{indent=1cm}), limited to its first
+system:
 
 \begin{lilypond}[indent=1cm,print-only=1]
+  \set Staff.instrumentName = "Violin"
   \repeat unfold 12 { c' d' e' d' }
 \end{lilypond}
 
@@ -37,46 +40,53 @@ In this case the indent of the first system is suppressed in order to avoid a
 “hole”. Of course this is a corner case, but might be useful when a score
 consists of separate entities (examples, exercises) per system.
 
-\textbf{Note:} this works correctly, so obviously there's something wrong with
-the entry conditional checking whether indent suppression should be applied.
-
-\begin{lilypond}[indent=1cm,print-only={3,1,2}]
+\begin{lilypond}[indent=1cm,print-only={3,1,2},max-protrusion=0.5cm]
   \repeat unfold 25 { c' d' e' d' }
 \end{lilypond}
 
-
 If a protrusion limit has been set with \texttt{max-protrusion=0.5cm} and the
-score exceeds that limit in spite of an indent then the whole score will
-appropriately be indented:
+score exceeds that limit in spite of \texttt{indent=1cm} then the whole score
+will appropriately be narrowed:
 
 \begin{lilypond}[indent=1cm,max-protrusion=0.5cm]
   \set Staff.instrumentName = "Violin I. and II."
   \repeat unfold 11 { c' d' e' d' }
 \end{lilypond}
 
-This doesn't look very good because the indentation of the consecutive systems
-isn't actually necessary if only the first systems has that excessive
-protrusion. To improve that situation the option \texttt{autoindent} will add an
-automatic indent so only the first system is sufficiently indented:
 
-\textbf{This is broken:} autoindent doesn't seem to make a difference.
+This doesn't really look good because the indentation of the second system
+wouldn't have been necessary since only the first system exceeds the protrusion
+limit. The solution to this situation is the option \texttt{autoindent} which
+handles the indentation \emph{automatically} and set the indent to a value that
+will make the \emph{first} system fit into the protrusion limit and leave the
+remaining systems unchanged:
 
-\begin{lilypond}[autoindent,max-protrusion=0.5cm]
+\begin{lilypond}[autoindent=true,max-protrusion=0cm]
   \set Staff.instrumentName = "Violin I. and II."
   \repeat unfold 11 { c' d' e' d' }
 \end{lilypond}
 
+
 However, if the protrusion limit is not only exceeded by the \emph{first} system
 (which should be the typical case due to the instrument name) \texttt{lyluatex}
-will deal with the situation by indenting the \emph{whole} score by the
-appropriate amount and adjusting the indent of the first system accordingly:
+will deal with the situation by narrowing the \emph{whole} score by the
+appropriate amount and adjusting the indent of the first system so all systems
+will just fit into the protrusion limit:
 
-\textbf{This is broken:} autoindent doesn't seem to make a difference.
-
-\begin{lilypond}[autoindent,max-protrusion=0.5cm]
+\begin{lilypond}[autoindent=true,max-protrusion=0.5cm]
   \set Staff.instrumentName = "Violin I. and II."
   \set Staff.shortInstrumentName = "Violin I/II"
   \repeat unfold 11 { c' d' e' d' }
+\end{lilypond}
+
+There is one special case to be mentioned. As described above the indent is
+deactivated if the first system of a score is printed at a later position.
+However, if this score will exceed the left protrusion limit \texttt{autoindent}
+will be automatically activated to avoid having the \emph{whole} score narrowed:
+
+\begin{lilypond}[indent=1cm,print-only={3,1,2},max-protrusion=0.5cm]
+  \set Staff.instrumentName = "Violin"
+  \repeat unfold 25 { c' d' e' d' }
 \end{lilypond}
 
 
@@ -84,5 +94,12 @@ The handling of indent suppression may require up to four compilations of the
 score, but these are handled automatically, and the resulting intermediate
 stages of the score are cached just like the scores actually used in the
 document.
+
+The \texttt{autoindent} option is active by default but will be deactivated if
+\texttt{indent} is set explicitly. It has to be noted that this option will add
+more LilyPond compilations and therefore compilation time. But it will only
+apply and be executed if the score exceeds the protrusion limit, so it can only
+occur in circumstances where multiple LilyPond runs are expected anyway.
+
 
 \end{document}

--- a/examples/dynamic-indent.tex
+++ b/examples/dynamic-indent.tex
@@ -1,0 +1,82 @@
+\documentclass{scrartcl}
+\usepackage{lyluatex}
+\newcommand{\postLilyPondExample}{\par\bigskip\hrule\par\bigskip}
+\begin{document}
+
+\section*{System Selection and Indent Suppression}
+
+This document demonstrates the use of \texttt{print-only} and \texttt{indent}.
+With \texttt{print-only} the output can be limited to a selection of systems or
+pages in arbitrary order.  \texttt{lyluatex} suppresses a given indent if either
+only the first (or single) system is printed or the first systems happens to be
+printed not at the first position.  If necessary one or several recompilation(s)
+are triggered automatically.
+
+\bigskip The following score has an indent of 1cm but only a single system.
+Therefore the indent is deactivated and the score shifted to the left.  Since
+the score itself has only one system no recompilation is required because the
+score is ragged-right anyway.
+
+\begin{lilypond}[indent=1cm]
+  { c' d' e' d' }
+\end{lilypond}
+
+The following score has an indent of 1cm set and \texttt{print-only=3-1},
+therefore the indented first system wouldn't be at the top of the score. Since
+simply shifting the system to the left would create a “hole” on the right side
+the score is automatically recompiled without indentation.
+
+\begin{lilypond}[print-only=3-1,indent=1cm]
+  \repeat unfold 28 { c' d' e' d' }
+\end{lilypond}
+
+The following score has the same properties as the previous ones but
+additionally a \texttt{max-protrusion} limit of 0.5cm and a protruding
+instrument name.  This results in the situation that normally the whole score
+would be shortened to fit in the maximum protrusion because the indent is
+automatically deactivated:
+
+\begin{lilypond}[print-only=2-1,max-protrusion=0.5cm]
+  \set Staff.instrumentName = "Violin"
+  \repeat unfold 15 { c' d' e' d' }
+\end{lilypond}
+
+However, since an indent is given \texttt{lyluatex} tries to fix the protrusion
+issue first by reintroducing an indent up to the given value.  This is because
+in a majority of cases the protrusion limit will be be exceeded by instrument
+names in the first system (which is what indent basically is used for).  In
+this score this is sufficient, so only the first system is indented and not the
+whole score.
+
+\begin{lilypond}[autoindent, indent=1cm,max-protrusion=0.5cm]
+  \set Staff.instrumentName = "Violin"
+  \repeat unfold 15 { c' d' e' d' }
+\end{lilypond}
+
+If the protrusion is so wide that it would exceed the allowed indent the whole
+score will be narrowed by the necessary additional amount:
+
+\begin{lilypond}[print-only=2-1,indent=10cm,max-protrusion=0.5cm]
+  \set Staff.instrumentName = "Violin I. and II."
+  \repeat unfold 15 { c' d' e' d' }
+\end{lilypond}
+
+Finally it is possible that after applying the dynamic indent there still is a
+protrusion overflow caused by other systems than the first one.  In this case
+the score is narrowed according to the protrusion and the dynamic indent reduced
+accordingly:
+
+\begin{lilypond}[print-only=2-1,indent=1cm,max-protrusion=0.5cm]
+  \set Staff.instrumentName = "Violin 1"
+  \set Staff.shortInstrumentName = "Violin"
+  \repeat unfold 15 { c' d' e' d' }
+\end{lilypond}
+
+
+
+The handling of indent suppression may require up to four compilations of the
+score, but these are handled automatically, and the resulting intermediate
+stages of the score are cached just like the scores actually used in the
+document.
+
+\end{document}

--- a/examples/dynamic-indent.tex
+++ b/examples/dynamic-indent.tex
@@ -61,7 +61,7 @@ handles the indentation \emph{automatically} and set the indent to a value that
 will make the \emph{first} system fit into the protrusion limit and leave the
 remaining systems unchanged:
 
-\begin{lilypond}[autoindent=true,max-protrusion=0cm]
+\begin{lilypond}[autoindent=true,max-protrusion=0.5cm]
   \set Staff.instrumentName = "Violin I. and II."
   \repeat unfold 11 { c' d' e' d' }
 \end{lilypond}

--- a/examples/dynamic-indent.tex
+++ b/examples/dynamic-indent.tex
@@ -3,75 +3,81 @@
 \newcommand{\postLilyPondExample}{\par\bigskip\hrule\par\bigskip}
 \begin{document}
 
-\section*{System Selection and Indent Suppression}
+\section*{Indent Handling}
 
-This document demonstrates the use of \texttt{print-only} and \texttt{indent}.
-With \texttt{print-only} the output can be limited to a selection of systems or
-pages in arbitrary order.  \texttt{lyluatex} suppresses a given indent if either
-only the first (or single) system is printed or the first systems happens to be
-printed not at the first position.  If necessary one or several recompilation(s)
-are triggered automatically.
+This document demonstrates the use of \texttt{indent} and \texttt{autoindent},
+partially in combination with \texttt{print-only}.
 
-\bigskip The following score has an indent of 1cm but only a single system.
-Therefore the indent is deactivated and the score shifted to the left.  Since
-the score itself has only one system no recompilation is required because the
-score is ragged-right anyway.
+\texttt{indent=1cm} indents the first line, but if the resulting score contains
+only one system this indent is suppressed (issuing a warning on the console):
+
+\begin{lilypond}[indent=1cm]
+  \repeat unfold 12 { c' d' e' d' }
+\end{lilypond}
 
 \begin{lilypond}[indent=1cm]
   { c' d' e' d' }
 \end{lilypond}
 
-The following score has an indent of 1cm set and \texttt{print-only=3-1},
-therefore the indented first system wouldn't be at the top of the score. Since
-simply shifting the system to the left would create a “hole” on the right side
-the score is automatically recompiled without indentation.
+If the output of a score containing more than one system is limited to the first
+system using \texttt{print-only=1} then the indent is removed but the score is
+recompiled to ensure a full-length system. The following score is the first
+system of the first two-system score:
 
-\begin{lilypond}[print-only=3-1,indent=1cm]
-  \repeat unfold 28 { c' d' e' d' }
+\textbf{This is broken:} The indent should be suppressed. For
+this \emph{two} compilations would have been necessary instead of just one.
+
+\begin{lilypond}[indent=1cm,print-only=1]
+  \repeat unfold 12 { c' d' e' d' }
 \end{lilypond}
 
-The following score has the same properties as the previous ones but
-additionally a \texttt{max-protrusion} limit of 0.5cm and a protruding
-instrument name.  This results in the situation that normally the whole score
-would be shortened to fit in the maximum protrusion because the indent is
-automatically deactivated:
+Note that this behaviour also applies when \texttt{print-only} causes the first
+system to be printed at another position, e.g. with \texttt{print-only={3,1,2}}.
+In this case the indent of the first system is suppressed in order to avoid a
+“hole”. Of course this is a corner case, but might be useful when a score
+consists of separate entities (examples, exercises) per system.
 
-\begin{lilypond}[print-only=2-1,max-protrusion=0.5cm]
-  \set Staff.instrumentName = "Violin"
-  \repeat unfold 15 { c' d' e' d' }
+\textbf{Note:} this works correctly, so obviously there's something wrong with
+the entry conditional checking whether indent suppression should be applied.
+
+\begin{lilypond}[indent=1cm,print-only={3,1,2}]
+  \repeat unfold 25 { c' d' e' d' }
 \end{lilypond}
 
-However, since an indent is given \texttt{lyluatex} tries to fix the protrusion
-issue first by reintroducing an indent up to the given value.  This is because
-in a majority of cases the protrusion limit will be be exceeded by instrument
-names in the first system (which is what indent basically is used for).  In
-this score this is sufficient, so only the first system is indented and not the
-whole score.
 
-\begin{lilypond}[autoindent, indent=1cm,max-protrusion=0.5cm]
-  \set Staff.instrumentName = "Violin"
-  \repeat unfold 15 { c' d' e' d' }
-\end{lilypond}
+If a protrusion limit has been set with \texttt{max-protrusion=0.5cm} and the
+score exceeds that limit in spite of an indent then the whole score will
+appropriately be indented:
 
-If the protrusion is so wide that it would exceed the allowed indent the whole
-score will be narrowed by the necessary additional amount:
-
-\begin{lilypond}[print-only=2-1,indent=10cm,max-protrusion=0.5cm]
+\begin{lilypond}[indent=1cm,max-protrusion=0.5cm]
   \set Staff.instrumentName = "Violin I. and II."
-  \repeat unfold 15 { c' d' e' d' }
+  \repeat unfold 11 { c' d' e' d' }
 \end{lilypond}
 
-Finally it is possible that after applying the dynamic indent there still is a
-protrusion overflow caused by other systems than the first one.  In this case
-the score is narrowed according to the protrusion and the dynamic indent reduced
-accordingly:
+This doesn't look very good because the indentation of the consecutive systems
+isn't actually necessary if only the first systems has that excessive
+protrusion. To improve that situation the option \texttt{autoindent} will add an
+automatic indent so only the first system is sufficiently indented:
 
-\begin{lilypond}[print-only=2-1,indent=1cm,max-protrusion=0.5cm]
-  \set Staff.instrumentName = "Violin 1"
-  \set Staff.shortInstrumentName = "Violin"
-  \repeat unfold 15 { c' d' e' d' }
+\textbf{This is broken:} autoindent doesn't seem to make a difference.
+
+\begin{lilypond}[autoindent,max-protrusion=0.5cm]
+  \set Staff.instrumentName = "Violin I. and II."
+  \repeat unfold 11 { c' d' e' d' }
 \end{lilypond}
 
+However, if the protrusion limit is not only exceeded by the \emph{first} system
+(which should be the typical case due to the instrument name) \texttt{lyluatex}
+will deal with the situation by indenting the \emph{whole} score by the
+appropriate amount and adjusting the indent of the first system accordingly:
+
+\textbf{This is broken:} autoindent doesn't seem to make a difference.
+
+\begin{lilypond}[autoindent,max-protrusion=0.5cm]
+  \set Staff.instrumentName = "Violin I. and II."
+  \set Staff.shortInstrumentName = "Violin I/II"
+  \repeat unfold 11 { c' d' e' d' }
+\end{lilypond}
 
 
 The handling of indent suppression may require up to four compilations of the

--- a/examples/dynamic-indent.tex
+++ b/examples/dynamic-indent.tex
@@ -120,16 +120,24 @@ more LilyPond compilations and therefore compilation time. But it will only
 apply and be executed if the score exceeds the protrusion limit, so it can only
 occur in circumstances where multiple LilyPond runs are expected anyway.
 
+\newpage
 \paragraph{Known Issues:}
 If \texttt{autoindent} is implicitly set like in the following example, and
 \texttt{max-protrusion=0cm} then the indented first system doesn't correctly
 refer to the text margin (\texttt{=0cm}) but to the staff symbol of the
-surrounding systems.
+surrounding systems:
 
 \begin{lilypond}[indent=1cm,print-only={3,1,2},max-protrusion=0cm]
   \set Staff.instrumentName = "Violin"
-  \repeat unfold 25 { c' d' e' d' }
+  \repeat unfold 19 { c' d' e' d' }
 \end{lilypond}
 
+This does only happen with the \emph{implicit} autoindent after a deactivated
+indent. Regular files are autoindented correctly:
+
+\begin{lilypond}[max-protrusion=0cm]
+  \set Staff.instrumentName = "Violin"
+  \repeat unfold 19 { c' d' e' d' }
+\end{lilypond}
 
 \end{document}

--- a/examples/print-only.tex
+++ b/examples/print-only.tex
@@ -33,8 +33,15 @@ the score is automatically recompiled without indentation.
 The following score has the same properties as the previous ones but
 additionally a \texttt{max-protrusion} limit of 0.5cm and a protruding
 instrument name.  This results in the situation that normally the whole score
-would be shortened to fit in the maximum protrusion.
-If an indent is given as an option \texttt{lyluatex} tries to fix the protrusion
+would be shortened to fit in the maximum protrusion because the indent is
+automatically deactivated:
+
+\begin{lilypond}[print-only=2-1,max-protrusion=0.5cm]
+  \set Staff.instrumentName = "Violin"
+  \repeat unfold 15 { c' d' e' d' }
+\end{lilypond}
+
+However, since an indent is given \texttt{lyluatex} tries to fix the protrusion
 issue first by reintroducing an indent up to the given value.  This is because
 in a majority of cases the protrusion limit will be be exceeded by instrument
 names in the first system (which is what indent basically is used for).  In

--- a/examples/print-only.tex
+++ b/examples/print-only.tex
@@ -1,0 +1,24 @@
+\documentclass{scrartcl}
+
+\usepackage{lyluatex}
+\begin{document}
+
+\newcommand{\preLilyPondExample}{\par\bigskip\hrule\par\bigskip}
+
+The following score has an indent of 1cm but only a single system. Therefore the
+indent is deactivated and the score shifted to the left.
+
+\begin{lilypond}[indent=1cm]
+  { c' d' e' d' }
+\end{lilypond}
+
+The following score has an indent of 1cm set and \texttt{print-only=3-1},
+therefore the indented first system wouldn't be at the top of the score. Since
+simply shifting the system to the left would create a “hole” on the right side
+the score is automatically recompiled without indentation.
+
+\begin{lilypond}[print-only=3-1,indent=1cm]
+  \repeat unfold 128 { c' d' e' d' }
+\end{lilypond}
+
+\end{document}

--- a/examples/print-only.tex
+++ b/examples/print-only.tex
@@ -1,12 +1,21 @@
 \documentclass{scrartcl}
-
 \usepackage{lyluatex}
+\newcommand{\postLilyPondExample}{\par\bigskip\hrule\par\bigskip}
 \begin{document}
 
-\newcommand{\preLilyPondExample}{\par\bigskip\hrule\par\bigskip}
+\section*{System Selection and Indent Suppression}
 
-The following score has an indent of 1cm but only a single system. Therefore the
-indent is deactivated and the score shifted to the left.
+This document demonstrates the use of \texttt{print-only} and \texttt{indent}.
+With \texttt{print-only} the output can be limited to a selection of systems or
+pages in arbitrary order.  \texttt{lyluatex} suppresses a given indent if either
+only the first (or single) system is printed or the first systems happens to be
+printed not at the first position.  If necessary one or several recompilation(s)
+are triggered automatically.
+
+\bigskip The following score has an indent of 1cm but only a single system.
+Therefore the indent is deactivated and the score shifted to the left.  Since
+the score itself has only one system no recompilation is required because the
+score is ragged-right anyway.
 
 \begin{lilypond}[indent=1cm]
   { c' d' e' d' }
@@ -18,7 +27,49 @@ simply shifting the system to the left would create a “hole” on the right si
 the score is automatically recompiled without indentation.
 
 \begin{lilypond}[print-only=3-1,indent=1cm]
-  \repeat unfold 128 { c' d' e' d' }
+  \repeat unfold 28 { c' d' e' d' }
 \end{lilypond}
+
+The following score has the same properties as the previous ones but
+additionally a \texttt{max-protrusion} limit of 0.5cm and a protruding
+instrument name.  This results in the situation that normally the whole score
+would be shortened to fit in the maximum protrusion.
+If an indent is given as an option \texttt{lyluatex} tries to fix the protrusion
+issue first by reintroducing an indent up to the given value.  This is because
+in a majority of cases the protrusion limit will be be exceeded by instrument
+names in the first system (which is what indent basically is used for).  In
+this score this is sufficient, so only the first system is indented and not the
+whole score.
+
+\begin{lilypond}[print-only=2-1,indent=1cm,max-protrusion=0.5cm]
+  \set Staff.instrumentName = "Violin"
+  \repeat unfold 15 { c' d' e' d' }
+\end{lilypond}
+
+If the protrusion is so wide that it would exceed the allowed indent the whole
+score will be narrowed by the necessary additional amount:
+
+\begin{lilypond}[print-only=2-1,indent=1cm,max-protrusion=0.5cm]
+  \set Staff.instrumentName = "Violin I. and II."
+  \repeat unfold 15 { c' d' e' d' }
+\end{lilypond}
+
+Finally it is possible that after applying the dynamic indent there still is a
+protrusion overflow caused by other systems than the first one.  In this case
+the score is narrowed according to the protrusion and the dynamic indent reduced
+accordingly:
+
+\begin{lilypond}[print-only=2-1,indent=1cm,max-protrusion=0.5cm]
+  \set Staff.instrumentName = "Violin 1"
+  \set Staff.shortInstrumentName = "Violin"
+  \repeat unfold 15 { c' d' e' d' }
+\end{lilypond}
+
+
+
+The handling of indent suppression may require up to four compilations of the
+score, but these are handled automatically, and the resulting intermediate
+stages of the score are cached just like the scores actually used in the
+document.
 
 \end{document}

--- a/examples/print-only.tex
+++ b/examples/print-only.tex
@@ -48,7 +48,7 @@ names in the first system (which is what indent basically is used for).  In
 this score this is sufficient, so only the first system is indented and not the
 whole score.
 
-\begin{lilypond}[print-only=2-1,indent=1cm,max-protrusion=0.5cm]
+\begin{lilypond}[autoindent, indent=1cm,max-protrusion=0.5cm]
   \set Staff.instrumentName = "Violin"
   \repeat unfold 15 { c' d' e' d' }
 \end{lilypond}
@@ -56,7 +56,7 @@ whole score.
 If the protrusion is so wide that it would exceed the allowed indent the whole
 score will be narrowed by the necessary additional amount:
 
-\begin{lilypond}[print-only=2-1,indent=1cm,max-protrusion=0.5cm]
+\begin{lilypond}[print-only=2-1,indent=10cm,max-protrusion=0.5cm]
   \set Staff.instrumentName = "Violin I. and II."
   \repeat unfold 15 { c' d' e' d' }
 \end{lilypond}

--- a/examples/print-only.tex
+++ b/examples/print-only.tex
@@ -3,80 +3,47 @@
 \newcommand{\postLilyPondExample}{\par\bigskip\hrule\par\bigskip}
 \begin{document}
 
-\section*{System Selection and Indent Suppression}
+\section*{Print only Selected Systems or Pages}
 
-This document demonstrates the use of \texttt{print-only} and \texttt{indent}.
-With \texttt{print-only} the output can be limited to a selection of systems or
-pages in arbitrary order.  \texttt{lyluatex} suppresses a given indent if either
-only the first (or single) system is printed or the first systems happens to be
-printed not at the first position.  If necessary one or several recompilation(s)
-are triggered automatically.
+The \texttt{print-only} option allows to limit the printed systems or pages from
+a score. A typical use case is to print a score interspersed with comments.  The
+advantage of this approach is that the score is compiled only once while the
+individual systems are simply reused by \LaTeX.
 
-\bigskip The following score has an indent of 1cm but only a single system.
-Therefore the indent is deactivated and the score shifted to the left.  Since
-the score itself has only one system no recompilation is required because the
-score is ragged-right anyway.
+Throughout this document we'll demonstrate the different options to
+select systems from the following score:
 
-\begin{lilypond}[indent=1cm]
-  { c' d' e' d' }
-\end{lilypond}
+\lilypondfile[verbatim]{../ly/eight-systems.ly}
 
-The following score has an indent of 1cm set and \texttt{print-only=3-1},
-therefore the indented first system wouldn't be at the top of the score. Since
-simply shifting the system to the left would create a “hole” on the right side
-the score is automatically recompiled without indentation.
+The simplest selection is a single system: \texttt{print-only=4}
 
-\begin{lilypond}[print-only=3-1,indent=1cm]
-  \repeat unfold 28 { c' d' e' d' }
-\end{lilypond}
+\lilypondfile[print-only=4]{../ly/eight-systems.ly}
 
-The following score has the same properties as the previous ones but
-additionally a \texttt{max-protrusion} limit of 0.5cm and a protruding
-instrument name.  This results in the situation that normally the whole score
-would be shortened to fit in the maximum protrusion because the indent is
-automatically deactivated:
+Ranges are also possible: \texttt{print-only=3-5}, with the special form of
+\texttt{print-only=6-} which prints from the given system throughout the end of
+the score. Negative ranges can be given with \texttt{print-only=7-5}
 
-\begin{lilypond}[print-only=2-1,max-protrusion=0.5cm]
-  \set Staff.instrumentName = "Violin"
-  \repeat unfold 15 { c' d' e' d' }
-\end{lilypond}
+\lilypondfile[print-only=3-5]{../ly/eight-systems.ly}
 
-However, since an indent is given \texttt{lyluatex} tries to fix the protrusion
-issue first by reintroducing an indent up to the given value.  This is because
-in a majority of cases the protrusion limit will be be exceeded by instrument
-names in the first system (which is what indent basically is used for).  In
-this score this is sufficient, so only the first system is indented and not the
-whole score.
+\lilypondfile[print-only=6-]{../ly/eight-systems.ly}
 
-\begin{lilypond}[autoindent, indent=1cm,max-protrusion=0.5cm]
-  \set Staff.instrumentName = "Violin"
-  \repeat unfold 15 { c' d' e' d' }
-\end{lilypond}
+\lilypondfile[print-only=7-5]{../ly/eight-systems.ly}
 
-If the protrusion is so wide that it would exceed the allowed indent the whole
-score will be narrowed by the necessary additional amount:
+With a comma-separated list an arbitrary sequence of systems can be specified.
+The list has to be enclosed in curly brackets: \texttt{print-only={4,1,2}}
 
-\begin{lilypond}[print-only=2-1,indent=10cm,max-protrusion=0.5cm]
-  \set Staff.instrumentName = "Violin I. and II."
-  \repeat unfold 15 { c' d' e' d' }
-\end{lilypond}
+\lilypondfile[print-only={4,1,2}]{../ly/eight-systems.ly}
 
-Finally it is possible that after applying the dynamic indent there still is a
-protrusion overflow caused by other systems than the first one.  In this case
-the score is narrowed according to the protrusion and the dynamic indent reduced
-accordingly:
+Each element of the list can include any of the forms described above:\\
+\texttt{print-only={3,5-7,4,7-}}
 
-\begin{lilypond}[print-only=2-1,indent=1cm,max-protrusion=0.5cm]
-  \set Staff.instrumentName = "Violin 1"
-  \set Staff.shortInstrumentName = "Violin"
-  \repeat unfold 15 { c' d' e' d' }
-\end{lilypond}
+\lilypondfile[print-only={3,5-7,4,7-}]{../ly/eight-systems.ly}
 
+The functionality is identical with fullpage scores where the selection applies
+to \emph{pages} instead. This can for example be used when the “score” file
+contains a number of individual pieces (e.g. songs for a song book), and
+individual selections are to be printed.
 
-
-The handling of indent suppression may require up to four compilations of the
-score, but these are handled automatically, and the resulting intermediate
-stages of the score are cached just like the scores actually used in the
-document.
+Systems have some specific behaviour with regard to \emph{indent}, but this is demonstrated in its own file \texttt{dynamic-indent.tex}.
 
 \end{document}

--- a/ly/eight-systems.ly
+++ b/ly/eight-systems.ly
@@ -1,0 +1,13 @@
+\version "2.18"
+
+\relative c' {
+  \omit Staff.TimeSignature
+  c1 \break
+  d1 \break
+  e1 \break
+  f1 \break
+  g1 \break
+  a1 \break
+  b1 \break
+  c1 \break
+}

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -549,12 +549,12 @@ function Score:calc_staff_properties()
 end
 
 function Score:check_indent(shorten)
-    if not self.original_indent and (
+    if not (self.original_indent and (
             -- Either only first system
             #self.range == 1 and self.range[1] == 1 or
             -- or system one not printed first in a multi-system range
             #self.range > 1 and self.range[1] ~= 1 and contains(self.range, 1)
-    ) then
+    )) then
         self.indent_offset = 0
         return shorten, false
     end

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -1061,8 +1061,8 @@ function Score:process()
     self.first_page = tex.count['c@page']
     self:check_properties()
     self:calc_properties()
-    self:check_protrusion(bbox.read)
-    local do_compile = not self:is_compiled()
+    local do_compile = not self:is_compiled() or
+        self:check_protrusion(bbox.read)
     if do_compile then
         repeat
             self:run_lilypond(self:header()..self:content())

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -549,13 +549,16 @@ function Score:calc_staff_properties()
 end
 
 function Score:check_indent(shorten)
+    if self.autoindent == '' then
+        if not (#self.range > 1 and self.range[1] ~= 1 and contains(self.range, 1)) then
+            self.autoindent = false
+        end
+    end
     if not (self.original_indent and (
             -- Either only first system
             #self.range == 1 and self.range[1] == 1 or
             -- or autoindent is specified
-            self.autoindent or
-            -- or system one not printed first in a multi-system range
-            #self.range > 1 and self.range[1] ~= 1 and contains(self.range, 1)
+            self.autoindent
     )) then
         self.indent_offset = 0
         return shorten, false

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -438,8 +438,7 @@ function Score:new(ly_code, options, input_file)
 end
 
 function Score:bbox(system)
-    if system
-    then
+    if system then
         if not self.bboxes then
             self.bboxes = {}
             for i = 1, self:count_systems() do
@@ -448,8 +447,7 @@ function Score:bbox(system)
         end
         return self.bboxes[system]
     else
-        if not self.bbox
-        then
+        if not self.bbox then
             self.bbox = bbox.get(self.output, self['line-width'])
         end
         return self.bbox
@@ -529,7 +527,7 @@ function Score:calc_range()
         end
     end
     local result = {}
-    if tonumber(self['print-only']) then result = { self['print-only'] }
+    if tonumber(self['print-only']) then result = {self['print-only']}
     else
         for _, r in pairs(self['print-only']:explode(',')) do
             local range = range_parse(r:gsub('^%s', ''):gsub('%s$', ''), nsystems)
@@ -557,7 +555,7 @@ function Score:calc_staff_properties()
     end
 end
 
-function Score:check_indent(lp, bb)
+function Score:check_indent(lp)
     local nsystems = self:count_systems()
 
     local function handle_autoindent()
@@ -659,11 +657,10 @@ Found something incompatible with `fragment`
 end
 
 function Score:check_protrusion(bbox_func)
+    self.range = self:calc_range()
     if self.insert ~= 'systems' then return self:is_compiled() end
     local bb = bbox_func(self.output, self['line-width'])
     if not bb then return end
-    -- Now we know there is a compiled score
-    self.range = self:calc_range()
 
     -- line_props lp
     local lp = {}
@@ -1210,10 +1207,9 @@ function Score:tex_margin_top()
 end
 
 function Score:write_latex(do_compile)
-    if self['raw-pdf']
-    then
+    if self['raw-pdf'] then
         if self.insert == 'systems' then
-            latex.systems_list(self.output, self.protrusion_left, self:_range())
+            latex.systems_list(self.output, self.protrusion_left, self.range)
         else tex.sprint(self.output) end
         return
     end

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -502,6 +502,8 @@ function Score:calc_properties()
     -- store for comparing protrusion against
     self.original_lw = self['line-width']
     self.original_indent = self.indent
+    -- explicit indent disables autoindent
+    if self.indent then self.autoindent = false end
     -- score fonts
     if self['current-font-as-main'] then
         self.rmfamily = self['current-font']
@@ -590,8 +592,6 @@ function Score:check_indent(shorten)
         return self.original_indent and (nsystems == 1)
     end
 
-    if type(self.autoindent) == 'string' then
-        self.autoindent = default_autoindent() end
     if simple_noindent() then
         self.indent_offset = self.indent
         warn('Deactivate indent for single-system score.')

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -577,22 +577,18 @@ function Score:check_indent(lp, bb)
         if not self.indent_offset then
             -- First step: deactivate indent
             self.indent_offset = 0
-            local recompile = ''
             if self:count_systems() > 1 then
                 -- only recompile if the *original* score has more than 1 system
                 self.indent = 0
                 lp.changed_indent = true
-                recompile = '.\nRecompile'
-            else self.indent_offset = self.indent or 0
             end
-            warn('Deactivate indentation because of system selection'..recompile)
+            info('Deactivate indentation because of system selection')
         elseif lp.shorten > 0 then
                 self.indent = 0
                 self.autoindent = true
 --                lp.changed_indent = true
                 handle_autoindent()
-                warn([[Deactivated indent causes protrusion.
-Recompile with autoindent.]])
+                info('Deactivated indent causes protrusion.')
         end
     end
 
@@ -693,12 +689,12 @@ function Score:check_protrusion(bbox_func)
     if lp.shorten > 0 or lp.changed_indent then
         self['line-width'] = self['line-width'] - lp.shorten
         -- recalculate hash to reflect the reduced line-width
-        if not lp.changed_indent then
-            warn([[Compiled score exceeds protrusion limit(s).
-Recompile with smaller line-width.]])
-        else warn([[Adjusted indent. Recompiling]])
+        if lp.shorten > 0 then
+            info('Compiled score exceeds protrusion limit(s)')
         end
+        if lp.changed_indent then info([[Adjusted indent.]]) end
         self.output = self:output_filename()
+        warn('Recompile or reuse cached score')
         return
     else return true
     end

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -549,10 +549,18 @@ function Score:calc_staff_properties()
 end
 
 function Score:check_indent(shorten)
+    -- if autoindent is not specified then make it default
+    -- *when system 1 is printed at a later position*
     if self.autoindent == '' then
-        if not (#self.range > 1 and self.range[1] ~= 1 and contains(self.range, 1)) then
-            self.autoindent = false
-        end
+        self.autoindent =
+            (#self.range > 1 and
+             self.range[1] ~= 1 and
+              contains(self.range, 1))
+    end
+    -- simply deactivate indent
+    if self.original_indent and (self:count_systems(true) == 1) then
+        self.indent_offset = self.indent
+        return shorten, false
     end
     if not (self.original_indent and (
             -- Either only first system
@@ -1072,6 +1080,7 @@ function Score:optimize_pdf()
 end
 
 local HASHIGNORE = {
+  'autoindent',
   'cleantmp',
   'hpadding',
   'max-left-protrusion',

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -548,7 +548,10 @@ function Score:check_indent(shorten)
          (#self.range > 1 and
           self.range[1] ~= 1 and
           contains(self.range, 1))))
-    then return shorten, false end
+    then
+        self.indent_offset = 0
+        return shorten, false
+    end
 
     -- Now we know we have to deal with the indent
     local changed = false

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -1133,7 +1133,7 @@ function Score:process()
     local do_compile = not self:check_protrusion(bbox.read)
     if do_compile then
         repeat self:run_lilypond(self:header()..self:content())
-        until self:check_protrusion(bbox.read) or self:check_protrusion(bbox.parse)
+        until self:check_protrusion(bbox.get)
         self:optimize_pdf()
     else table.insert(self.output_names, self.output)
     end

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -22,8 +22,7 @@
   ly = require(kpse.find_file("lyluatex.lua") or "lyluatex.lua")
   ly.declare_package_options({
     ['addversion'] = {'false', 'true', ''},
-    ['autoindent'] = {'', 'true', 'false'},
-        ['noautoindent'] = {'default', ly.is_neg},
+    ['autoindent'] = {'true', 'false', ''},
     ['cleantmp'] = {'false', 'true', ''},
     ['currfiledir'] = {},
     ['debug'] = {'false', 'true', ''},

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -22,6 +22,7 @@
   ly = require(kpse.find_file("lyluatex.lua") or "lyluatex.lua")
   ly.declare_package_options({
     ['addversion'] = {'false', 'true', ''},
+    ['autoindent'] = {'false', 'true', ''},
     ['cleantmp'] = {'false', 'true', ''},
     ['currfiledir'] = {},
     ['debug'] = {'false', 'true', ''},

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -22,7 +22,8 @@
   ly = require(kpse.find_file("lyluatex.lua") or "lyluatex.lua")
   ly.declare_package_options({
     ['addversion'] = {'false', 'true', ''},
-    ['autoindent'] = {'false', 'true', ''},
+    ['autoindent'] = {'', 'true', 'false'},
+        ['noautoindent'] = {'default', ly.is_neg},
     ['cleantmp'] = {'false', 'true', ''},
     ['currfiledir'] = {},
     ['debug'] = {'false', 'true', ''},

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -180,7 +180,7 @@
 
 % Inclusion of a .ly file
 \newcommand*\includely[2][]{%
-\directlua{ly.state = 'file'}%
+  \directlua{ly.state = 'file'}%
   \ly@compilescore{ly.file(
     '\luatexluaescapestring{#2}', [[#1]]
   )}%
@@ -188,6 +188,7 @@
 
 % Inclusion of a musicxml file
 \newcommand*\musicxmlfile[2][]{%
+  \directlua{ly.state = 'file'}%
   \ly@compilescore{ly.file_musicxml(
     '\luatexluaescapestring{#2}', [[#1]]
   )}


### PR DESCRIPTION
 calc range already in the compilation loop
- check for indent there (not when writing systems to LaTeX)
- deactivate indent when
  - only system no. 1 is printed
    (because score only has one system or due to print-only)
  - the first system is *not* printed first (through print-only)
- if indent is deactivated and the score has more than one system
  then recompile without indent to have a properly filled system
  (and not one that is just shifted left)

See new example file

Based on #153