### PR TITLE
Better handling of current-font-as-main

### DIFF
--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -1459,8 +1459,10 @@ function ly.set_fonts(rm, sf, tt)
       ly.score.rmfamily = ly.get_font_family(rm)
   else
       -- if explicitly set don't override rmfamily with 'current' font
-      ly.score['current-font-as-main'] = 'false'
-      info("rmfamily set explicitly. Deactivate 'current-font-as-main'")
+      if ly.score['current-font-as-main'] then
+          info("rmfamily set explicitly. Deactivate 'current-font-as-main'")
+      end
+      ly.score['current-font-as-main'] = false
   end
   if ly.score.sffamily == '' then
       ly.score.sffamily = ly.get_font_family(sf)

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -58,7 +58,7 @@
     ['paperheight'] = {[[\paperheight]], ly.is_dim},
     ['papersize'] = {'false'},
     ['pass-fonts'] = {'false', 'true', ''},
-        ['current-font'] = {}, ['current-font-as-main'] = {'true', 'false', ''},
+        ['current-font'] = {}, ['current-font-as-main'] = {'false', 'true', ''},
         ['rmfamily'] = {}, ['sffamily'] = {}, ['ttfamily'] = {},
     ['print-page-number'] = {'false', 'true', ''},
     ['print-only'] = {''},


### PR DESCRIPTION
While reviewing the manual section about fonts I changed some small details about the handling of `current-font-as-main`:

- default value is now 'false'
- if `rmfamily` is set then current-font-as-main is unconditionally set to false
- but only when it *is* set in the document a warning is issued

More explanations in https://github.com/jperon/lyluatex/commit/8b9bc1952eef1b94c5c09ca2a71f77099d9a2edf