### PR TITLE
Avoid infinite loop when there are errors in LilyPond code.

### DIFF
--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -741,11 +741,8 @@ end
 
 function Score:clean_failed_compilation()
     for file in lfs.dir(self.tmpdir) do
-        filename = self.tmpdir..'/'..file
-        if filename:find(self.output) then
-            print("Remove "..filename)
-            os.remove(filename)
-        end
+        local filename = self.tmpdir..'/'..file
+        if filename:find(self.output) then os.remove(filename) end
     end
 end
 
@@ -1063,8 +1060,7 @@ function Score:process()
     if do_compile then
         repeat
             self:run_lilypond(self:header()..self:content())
-            if self:is_compiled() then
-                table.insert(self.output_names, self.output)
+            if self:is_compiled() then table.insert(self.output_names, self.output)
             else
                 self:clean_failed_compilation()
                 break

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -1050,7 +1050,10 @@ function Score:process()
     if do_compile then
         repeat
             self:run_lilypond(self:header()..self:content())
-            if self:is_compiled() then table.insert(self.output_names, self.output) end
+            if self:is_compiled_without_error() then
+                table.insert(self.output_names, self.output)
+            else break
+            end
         until self:check_protrusion(bbox.get)
         self:optimize_pdf()
     else table.insert(self.output_names, self.output)

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -776,7 +776,13 @@ produced a score. %s
         return true
     else
         --[[ ensure the score gets recompiled next time --]]
-        os.execute('rm '..self.output..'*')
+        for file in lfs.dir(self.tmpdir) do
+            filename = self.tmpdir..'/'..file
+            if filename:find(self.output) then
+                print("Remove "..filename)
+                os.remove(filename)
+            end
+        end
         if self.showfailed then
             tex.sprint(string.format([[
 \begin{quote}


### PR DESCRIPTION
There was an infinite loop when a score contained invalid LilyPond code.