### PR TITLE
Add first-page-number and print-first-page-number options

### DIFF
--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -994,15 +994,20 @@ end
 function Score:ly_paper()
     local papersize = '#(set-paper-size "'..(self.papersize or 'lyluatexfmt')..'")'
     if self.insert == 'fullpage' then
+        local first_page_number = tex.count['c@page']
+        if self['first-page-number'] then
+            first_page_number = self['first-page-number'] end
+        local pfpn = 'f'
+        if self['print-first-page-number'] then pfpn = 't' end
         local ppn = 'f'
         if self['print-page-number'] then ppn = 't' end
         return string.format([[
 %s
 print-page-number = ##%s
-print-first-page-number = ##t
+print-first-page-number = ##%s
 first-page-number = %s
 %s]],
-            papersize, ppn, tex.count['c@page'], self:ly_margins()
+            papersize, ppn, pfpn, first_page_number, self:ly_margins()
 	    )
     elseif self.papersize then return papersize
     end

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -68,6 +68,8 @@
         ['current-font'] = {}, ['current-font-as-main'] = {'false', 'true', ''},
         ['rmfamily'] = {}, ['sffamily'] = {}, ['ttfamily'] = {},
     ['print-page-number'] = {'false', 'true', ''},
+        ['first-page-number'] = {''},
+        ['print-first-page-number'] = {'true', 'false', ''},
     ['print-only'] = {''},
     ['printfilename'] = {'false', 'true', ''},
     ['program'] = {'lilypond'},


### PR DESCRIPTION
a)
There may be the need to force a first page number (i.e. the start
with an odd or even page), especially in combination with the raw-pdf
option, when the resulting score is not immediately included in a score.
I came across this in a case where I want to first generate a number of
scores and afterwards include them in a row of documents (=> a set
of all parts for a score). I know that the scores will all start on an odd page
(because I'll take care of that) so I want to force LilyPond to think so,
regardless of what lyluatex thinks the "current page" is.

b)
Incidentally I think there may be reasons where the first page number may
*not* be wanted, even when included in a book.