### PR TITLE
Fix crash with comments in included LilyPond files

### DIFF
--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -832,6 +832,10 @@ function Score:flatten_content(ly_code)
         including referenced files (if they can be opened.
         Other files (from LilyPond's include path) are considered
         irrelevant for the purpose of a hashsum.) --]]
+
+    -- Replace percent signs with another character that doesn't
+    -- meddle with Lua's gsub escape character.
+    ly_code = ly_code:gsub('%%', '#')
     local f
     local includepaths = self.includepaths
     if self.input_file then includepaths = self.includepaths..','..dirname(self.input_file) end


### PR DESCRIPTION
Closes #197

When including LilyPond files that contain percent characters (i.e.
any comments) they cause the flatten_content() function to fail
because single percent chars are uncorrectly interpreted as
escape characters.

This commit replaces percents with hash characters - which doesn't
do any harm as this flattened LilyPond code will never be used by
LilyPond, only to generate a hash filename. (OTOH simply removing
them might have unwanted side effects).