### PR TITLE
force-compilation option

### DIFF
--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -38,6 +38,7 @@ local DIM_OPTIONS = {
 local HASHIGNORE = {
     'autoindent',
     'cleantmp',
+    'force-compilation',
     'hpadding',
     'max-left-protrusion',
     'max-right-protrusion',
@@ -858,6 +859,7 @@ function Score:header()
 end
 
 function Score:is_compiled()
+    if self['force-compilation'] then return false end
     return lfs.isfile(self.output..'.pdf') or self:count_systems(true) ~= 0
 end
 
@@ -1098,9 +1100,10 @@ function Score:process()
     -- with bbox.read check_ptrotrusion will only execute with
     -- a prior compilation, otherwise it will be ignored
     local do_compile = not self:check_protrusion(bbox.read)
-    if do_compile then
+    if self['force-compilation'] or do_compile then
         repeat
             self:run_lilypond(self:header()..self:content())
+            self['force-compilation'] = false
             if self:is_compiled() then table.insert(self.output_names, self.output)
             else
                 self:clean_failed_compilation()

--- a/lyluatex.md
+++ b/lyluatex.md
@@ -1167,6 +1167,17 @@ skipped, but nothing will be included in the document.  If on the other hand
 \option{showfailed} is set to `true` only a warning is issued and a box with an
 informative text is typeset into the resulting document.
 
+### Forcing (Re-)Compilation
+
+\lyOption{force-compilation}{false}
+
+In some cases \lyluatex's heuristics to determine the need for recompilation may
+fail, especially when not all relevant code is included through LilyPond's
+\cmd{include} command, in which cases \lyluatex\ may consider the content
+unchanged. In such cases the \option{force-compilation} option skips the checks
+and unconditionally recompiles the score, which may be a better solution than
+to (selectively) delete the scores from the \option{tmpdir} directory.
+
 ## MusicXML options
 
 \lyOption{xml2ly}{musicxml2ly}

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -35,6 +35,7 @@
     ['debug'] = {'false', 'true', ''},
     ['extra-bottom-margin'] = {'0', ly.is_dim},
     ['extra-top-margin'] = {'0', ly.is_dim},
+    ['force-compilation'] = {'false', 'true', ''},
     ['fragment'] = {'', 'false', 'true'},
         ['nofragment'] = {'default', ly.is_neg},
     ['fullpagealign'] = {'crop', 'staffline'},


### PR DESCRIPTION
In some cases the heuristics can't detect the need for recompilation because not all content is included through `\include`. In these cases the `force-compilation` option is better than asking the user to determine and remove the score from the temporary directory (which will often be not possible anyway, and the user would have to purge the directory completely).

I think this is pretty uncontroversial, and I'll take the approach of LilyPond's review process: if there are no objections within five days, I'll merge this myself.