### PR TITLE
Better way to handle optional arguments for ly.

### DIFF
--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -1291,22 +1291,6 @@ function ly.declare_package_options(options)
 end
 
 
-function ly.env_begin(opts)
-    ly.state = 'env'
-    ly.env_no_args = opts == 'noarg'
-    if ly.env_no_args then tex.sprint(40, [[\ly@compilely]])
-    else tex.sprint(40, [[\ly@bufferenv]])
-    end
-end
-
-
-function ly.env_end()
-    if ly.env_no_args then tex.sprint(40, [[\endly@compilely]])
-    else tex.sprint(40, [[\endly@bufferenv]])
-    end
-end
-
-
 function ly.file(input_file, options)
     --[[ Here, we only take in account global option includepaths,
     as it really doesn't mean anything as a local option. ]]

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -16,6 +16,7 @@
 \RequirePackage{environ}
 \RequirePackage{currfile}
 \RequirePackage{pdfpages}
+\RequirePackage{ifnextok}
 
 \RequirePackage{metalogo}
 \newcommand{\lyluatex}{\textit{ly}\LuaTeX}
@@ -212,12 +213,14 @@
 }
 
 % Parametrized command and environment for included LilyPond fragment
-\newenvironment{ly}[1][noarg]{%
+\newenvironment{ly@ly}[1][noarg]{%
   \edef\options{#1}%
-  \directlua{ly.env_begin([[#1]])}%
+  \ly@bufferenv%
 }{%
-  \directlua{ly.env_end()}%
+  \endly@bufferenv%
 }
+\def\ly{\IfNextToken[{\ly@ly}{\ly@ly[]}}
+\def\endly{\endly@ly}
 
 \newcommand*{\lily}[2][]{%
   \edef\options{#1}%


### PR DESCRIPTION
Should fix #194, #199, #205 within `ly`, and possibly ease wrapping
`ly` within other environments.

I think #194, #199, #205 and other such bugs should end with a
`wontfix` for `\lily`, as I don't see any solution with the way
`ly@compilely` passes the content to lua.