### PR TITLE
#224: Let LISTFILE respect tmpdir option

### DIFF
--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -1322,11 +1322,14 @@ function ly.declare_package_options(options)
         exopt = exopt..k..'='..(v[1] or '')..','
     end
     tex.sprint([[\ExecuteOptionsX{]]..exopt..[[}%%]], [[\ProcessOptionsX]])
-    mkdirs(options.tmpdir[1])
-    FILELIST = options.tmpdir[1]..'/'..splitext(status.log_name, 'log')..'.list'
-    os.remove(FILELIST)
 end
 
+function ly.make_list_file()
+    local tmpdir = ly.get_option('tmpdir')
+    mkdirs(tmpdir)
+    FILELIST = tmpdir..'/'..splitext(status.log_name, 'log')..'.list'
+    os.remove(FILELIST)
+end
 
 function ly.file(input_file, options)
     --[[ Here, we only take in account global option includepaths,

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -123,7 +123,7 @@
 \directlua{ly.make_list_file()}
 \directlua{
   if ly.get_option('cleantmp') then
-    luatexbase.add_to_callback('stop_run', ly.ly.declare_package_options, 'lyluatex cleantmp')
+    luatexbase.add_to_callback('stop_run', ly.clean_tmp_dir, 'lyluatex cleantmp')
     luatexbase.add_to_callback('stop_run', ly.conclusion_text, 'lyluatex conclusion')
   end
 }

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -120,9 +120,10 @@
     ['xml2ly'] = {'musicxml2ly'},
   })
 }
+\directlua{ly.make_list_file()}
 \directlua{
   if ly.get_option('cleantmp') then
-    luatexbase.add_to_callback('stop_run', ly.clean_tmp_dir, 'lyluatex cleantmp')
+    luatexbase.add_to_callback('stop_run', ly.ly.declare_package_options, 'lyluatex cleantmp')
     luatexbase.add_to_callback('stop_run', ly.conclusion_text, 'lyluatex conclusion')
   end
 }


### PR DESCRIPTION
LISTFILE was set to the *default* value of the tmpdir option because
writing \ExecuteOptionsX to the tex document doesn't update the option.
This has to take place in a new \directlua call.

Fixes #224