### PR TITLE
Customization commands

### DIFF
--- a/examples/wrappingcommands.tex
+++ b/examples/wrappingcommands.tex
@@ -14,7 +14,7 @@ This is \mylily[voffset=10pt]{a' b' c''} an example.
 
 \newcommand\mylily[2][1]{\lily[inline-staffsize=10, #1]{#2}}
 
-This is \mylily[voffset=10pt]{a' b' c''} an example.
+This is \mylily[voffset=10pt]{a' b' c''} an example.\par
 
 It's possible to wrap \highlight{ly} within and environment, but there are
 several drawbacks:

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -17,7 +17,6 @@ local ly = {
     err = err,
     varwidth_available = kpse.find_file('varwidth.sty')
 }
-local obj = {}
 local Score = {}
 
 local FILELIST
@@ -293,12 +292,25 @@ function bbox.get(filename, line_width)
     return bbox.read(filename) or bbox.parse(filename, line_width)
 end
 
+function bbox.calc(x_1, x_2, y_1, y_2, line_width)
+    local bb = {
+        ['protrusion'] = -convert_unit(("%fbp"):format(x_1)),
+        ['r_protrusion'] = convert_unit(("%fbp"):format(x_2)) - line_width,
+        ['width'] = convert_unit(("%fbp"):format(x_2))
+    }
+    --FIX #192: height is only calculated if really needed, to prevent errors with huge scores.
+    function bb.__index(_, k)
+        if k == 'height' then return convert_unit(("%fbp"):format(y_2)) - convert_unit(("%fbp"):format(y_1)) end
+    end
+    setmetatable(bb, bb)
+    return bb
+end
+
 function bbox.parse(filename, line_width)
     -- get BoundingBox from EPS file
     local bbline = readlinematching('^%%%%BoundingBox', io.open(filename..'.eps', 'r'))
     if not bbline then return end
-    --FIX #192: local x_1, y_1, x_2, y_2 = bbline:match('(%--%d+)%s(%--%d+)%s(%--%d+)%s(%--%d+)')
-    local x_1, _, x_2, _ = bbline:match('(%--%d+)%s(%--%d+)%s(%--%d+)%s(%--%d+)')
+    local x_1, y_1, x_2, y_2 = bbline:match('(%--%d+)%s(%--%d+)%s(%--%d+)%s(%--%d+)')
     -- try to get HiResBoundingBox from PDF (if 'gs' works)
     bbline = readlinematching(
         '^%%%%HiResBoundingBox',
@@ -312,21 +324,24 @@ function bbox.parse(filename, line_width)
         -- edge at the start of the staff symbol.
         -- Therefore we shift the HiRes results by the (truncated)
         -- points of the EPS bounding box.
-        --FIX #192: x_1, y_1, x_2, y_2 = pbb() + x_1, pbb() + y_1, pbb() + x_1, pbb() + y_1
-        x_1, x_2 = pbb() + x_1, pbb() + x_1
+        x_1, y_1, x_2, y_2 = pbb() + x_1, pbb() + y_1, pbb() + x_1, pbb() + y_1
     else warn([[gs couldn't be launched; there could be rounding errors.]])
     end
-    local bb = {
-        ['protrusion'] = -convert_unit(("%fbp"):format(x_1)),
-        ['r_protrusion'] = convert_unit(("%fbp"):format(x_2)) - line_width,
-        ['width'] = convert_unit(("%fbp"):format(x_2)),
-        --FIX #192: ['height'] = convert_unit(("%fbp"):format(y_2)) - convert_unit(("%fbp"):format(y_1))
-    }
-    obj.serialize(bb, filename..'.bbox')
-    return bb
+    local f = io.open(filename .. '.bbox', 'w')
+    f:write(
+        string.format("return %s, %s, %s, %s, %s", x_1, y_1, x_2, y_2, line_width)
+    )
+    f:close()
+    return bbox.calc(x_1, x_2, y_1, y_2, line_width)
 end
 
-function bbox.read(f) return obj.deserialize(f..'.bbox') end
+function bbox.read(f)
+    f = f .. '.bbox'
+    if lfs.isfile(f) then
+        local x_1, y_1, x_2, y_2, line_width = dofile(f)
+        return bbox.calc(x_1, x_2, y_1, y_2, line_width)
+    end
+end
 
 
 --[[ =============== Functions that output LaTeX code ===================== ]]
@@ -426,29 +441,6 @@ function latex.verbatim(verbatim, ly_code, intertext, version)
         f:close()
         tex.sprint('\\input{'..fname..'}')
         if intertext then tex.sprint('\\lyIntertext{'..intertext..'}') end
-    end
-end
-
-
---[[ =============== Functions that operate on objects ==================== ]]
-
-function obj.deserialize(f) if lfs.isfile(f) then return dofile(f) end end
-
-function obj.serialize(o, f)
-    f = io.open(f, 'w')
-    if not f then return end
-    f:write('local o = '..obj.str(o)..'\nreturn o')
-    f:close()
-end
-
-function obj.str(o)
-    if type(o) == "number" then return o
-    elseif type(o) == "string" then return string.format("%q", o)
-    elseif type(o) == "table" then
-        local r = '{\n'
-        for k, v in pairs(o) do r = r.."  ["..obj.str(k).."] = "..obj.str(v)..",\n" end
-        return r.."}\n"
-    else error("cannot convert " .. type(o).." to string")
     end
 end
 
@@ -1146,7 +1138,7 @@ end
 function Score:process()
     self:check_properties()
     self:calc_properties()
-    -- with bbox.read check_ptrotrusion will only execute with
+    -- with bbox.read check_protrusion will only execute with
     -- a prior compilation, otherwise it will be ignored
     local do_compile = not self:check_protrusion(bbox.read)
     if self['force-compilation'] or do_compile then

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -63,6 +63,10 @@
         ['exampleindent'] = {'gutter', ly.is_alias},
         ['leftgutter'] = {'', ly.is_dim}, ['rightgutter'] = {'', ly.is_dim},
     ['hpadding'] = {'0.75ex', ly.is_dim},
+    ['include_after_body'] = {'false'},
+    ['include_before_body'] = {'false'},
+    ['include_footer'] = {'false'},
+    ['include_header'] = {'false'},
     ['includepaths'] = {'./'},
     ['indent'] = {'', ly.is_dim},
         ['noindent'] = {'default', ly.is_neg},
@@ -251,6 +255,15 @@
     '\luatexluaescapestring{\detokenize{#1}}',
     '\luatexluaescapestring{\detokenize{#2}}'
   }}%
+}
+
+% Environments to record custom headers and footers to be included in fragments
+\newenvironment{lysavefrag}[1]{%
+  \edef\filename{#1}
+  \lyscorebegin%
+}{%
+  \lyscoreend%
+  \directlua{ly.write_to_file('\filename'..'.ly', table.concat(ly.score_content,'\string\n'))}%
 }
 
 % Commands to transform or define lilypond environments so that it isn't necessary to add empty [].

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -253,16 +253,28 @@
   }}%
 }
 
+% Commands to transform or define lilypond environments so that it isn't necessary to add empty [].
+\def\lyenv#1{%
+  \expandafter\let\csname ly@env@#1\expandafter\endcsname\csname #1\endcsname%
+  \expandafter\let\csname ly@env@end#1\expandafter\endcsname\csname end#1\endcsname%
+  \expandafter\def\csname #1\endcsname{\IfNextToken[{\csname ly@env@#1\endcsname}{\csname ly@env@#1\endcsname[]}}%
+}
+\long\def\lynewenvironment#1{\@ifnextchar[{\ly@newenv@a{#1}}{\ly@newenv@a{#1}[0]}}
+\long\def\ly@newenv@a#1[#2]{\@ifnextchar[{\ly@newenv@b{#1}{#2}}{\ly@newenv@b{#1}{#2}[]}}
+\long\def\ly@newenv@b#1#2[#3]#4#5{%
+  \newenvironment{#1}[#2][#3]{#4}{#5}
+  \lyenv{#1}
+}
+
 % Parametrized command and environment for included LilyPond fragment
-\newenvironment{ly@ly}[1][noarg]{%
+\lynewenvironment{ly}[1][noarg]{%
   \edef\options{#1}%
   \directlua{ly.state = 'env'}%
   \ly@bufferenv%
 }{%
   \endly@bufferenv%
 }
-\def\ly{\IfNextToken[{\ly@ly}{\ly@ly[]}}
-\def\endly{\endly@ly}
+
 
 \newcommand{\lily}[2][]{%
   \edef\options{#1}%


### PR DESCRIPTION
This PR includes several tools for customization:

- `\lynewenvironment` lets one define wrappers for `ly` without most of the drawbacks mentionned in the doc (especially the `[]` for empty optional arguments);
- as `\lynewenvironment` doesn't allow adding lilypond code between `\begin{ly}` and `\end{ly}` (but only latex code before and after), four new parameters allow it in various places, which must be defined to a filename (or a list of filenames) to include (without '.ly'):
  - `include_header`;
  - `include_footer`;
  - `include_before_body`;
  - `include_after_body`;
- `\lysavefrag{FILE}` allows defining lilypond code to be saved to `tmp-ly/FILE.ly`, so that it may be called from `include_...`.