### PR TITLE
Add system-count option 

### DIFF
--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -1029,20 +1029,39 @@ Given: %s
 end
 
 function Score:ly_paper()
+    local function get_system_count()
+        if self['system-count'] == 0 then
+            return ''
+        else
+            return 'system-count = '..self['system-count']..[[
+]]
+        end
+    end
+
+
     local papersize = '#(set-paper-size "'..(self.papersize or 'lyluatexfmt')..'")'
     if self.insert == 'fullpage' then
         local first_page_number = self['first-page-number'] or tex.count['c@page']
         local pfpn = self['print-first-page-number'] and 't' or 'f'
         local ppn = self['print-page-number'] and 't' or 'f'
         return string.format([[
-%s
+%s%s
     print-page-number = ##%s
     print-first-page-number = ##%s
     first-page-number = %s
 %s]],
-            papersize, ppn, pfpn, first_page_number, self:ly_margins()
+          get_system_count(), papersize, ppn, pfpn,
+          first_page_number, self:ly_margins()
 	    )
-    elseif self.papersize then return papersize
+    else
+        if self.papersize then
+            papersize = papersize..[[
+]]
+        else
+            papersize = ''
+        end
+
+        return string.format([[%s%s]], papersize, get_system_count())
     end
 end
 

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -966,16 +966,11 @@ function Score:ly_linewidth() return self['line-width'] end
 function Score:ly_staffsize() return self.staffsize end
 
 function Score:ly_margins()
-
-    local function horizontal_margins()
-        if self.twoside then
-            return string.format([[
-inner-margin = %s\pt]], self:tex_margin_inner())
-        else
-            return string.format([[
-left-margin = %s\pt]], self:tex_margin_left())
-        end
-    end
+    local horizontal_margins =
+        self.twoside and string.format([[
+            inner-margin = %s\pt]], self:tex_margin_inner())
+        or string.format([[
+            left-margin = %s\pt]], self:tex_margin_left())
 
     local tex_top = self['extra-top-margin'] + self:tex_margin_top()
     local tex_bottom = self['extra-bottom-margin'] + self:tex_margin_bottom()
@@ -984,7 +979,7 @@ left-margin = %s\pt]], self:tex_margin_left())
     top-margin = %s\pt
     bottom-margin = %s\pt
     %s]],
-            tex_top, tex_bottom, horizontal_margins()
+            tex_top, tex_bottom, horizontal_margins
         )
     elseif self.fullpagealign == 'staffline' then
         local top_distance = 4 * tex_top / self.staffsize + 2
@@ -1009,7 +1004,7 @@ left-margin = %s\pt]], self:tex_margin_left())
         (padding . 0)
         (stretchability . 0))
 ]],
-            horizontal_margins(),
+            horizontal_margins,
             top_distance,
             top_distance,
             top_distance,
@@ -1029,15 +1024,9 @@ Given: %s
 end
 
 function Score:ly_paper()
-    local function get_system_count()
-        if self['system-count'] == 0 then
-            return ''
-        else
-            return 'system-count = '..self['system-count']..[[
-]]
-        end
-    end
-
+    local system_count =
+        self['system-count'] == 0 and ''
+        or 'system-count = '..self['system-count']..'\n    '
 
     local papersize = '#(set-paper-size "'..(self.papersize or 'lyluatexfmt')..'")'
     if self.insert == 'fullpage' then
@@ -1050,7 +1039,7 @@ function Score:ly_paper()
     print-first-page-number = ##%s
     first-page-number = %s
 %s]],
-          get_system_count(), papersize, ppn, pfpn,
+          system_count, papersize, ppn, pfpn,
           first_page_number, self:ly_margins()
 	    )
     else
@@ -1061,7 +1050,7 @@ function Score:ly_paper()
             papersize = ''
         end
 
-        return string.format([[%s%s]], papersize, get_system_count())
+        return string.format([[%s%s]], papersize, system_count)
     end
 end
 

--- a/lyluatex.md
+++ b/lyluatex.md
@@ -469,6 +469,12 @@ By default, with \option{insert=fullpage}, scores are indented;
 otherwise, they aren't.
 \option{noindent} is equivalent to \option{indent=0pt}.  Please also see the section about [Dynamic Indentation](#indent).
 
+\lyOption{system-count}{}
+Forces LilyPond to produce a fixed number of systems. This may be useful when
+LilyPond breaks a score that can manually be squeezed to one system less, but
+it is also possible to spread out a score to more systems than LilyPond would
+consider necessary.
+
 \lyOption{quote}{false}
 This option, which is there for compatibility with `lilypond-book`,
 reduces line length of a music snippet by $2×0.4\,in$ and puts the output into

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -105,6 +105,7 @@
     ['showfailed'] = {'false', 'true' ,''},
     ['staffsize'] = {'0', ly.is_dim},
         ['inline-staffsize'] = {'0', ly.is_dim},
+    ['system-count'] = {'0', ly.is_dim},
     ['tmpdir'] = {'tmp-ly'},
     ['twoside'] = {'\ly@istwosided', 'false', 'true', ''},
     ['verbatim'] = {'false', 'true', ''},


### PR DESCRIPTION
If given the `\paper { system-count }` option is set in the ly_code. This can be very useful when LilyPond would by itself break the music on too many systems (e.g. one full system plus one measure), where forcing the system-count can make it work.

Produces
```lilypond
\paper{
    system-count = 2
    two-sided = ##f
```
in the relevant portion of the generated ly file