### PR TITLE
Gracefully handle failed LilyPond start with 'showfailed' option

### DIFF
--- a/lyluatex.md
+++ b/lyluatex.md
@@ -1158,7 +1158,9 @@ be detected and handled (if possible) by \lyluatex.  The most basic problem is
 when LilyPond can't be started at all.  \lyluatex\ will correctly determine and
 report an error if \LuaLaTeX\ has been started without the
 \option{--shell-escape} option or if the \option{program} option doesn't point
-to a valid LilyPond executable.
+to a valid LilyPond executable. However, if the \option{showfailed} option is
+also set then only a *warning* is issued while instead of a score an information
+box is created in the document, informing about the problem.
 
 Two other situations that are correctly recognized are when LilyPond *reports* a
 compilation failure but still produces a (potentially useful) score, and when


### PR DESCRIPTION
I think the 'showfailed' option should not only cover cases when LilyPond
fails to produce a score but also when it can't be started.

With the showfailed option a failure to start LilyPond does not result
in an err() but in a warn() with the same text, and a box is written
into the document like the one reporting a failed score compilation.

With this option it is for example possible to have people successfully
compile a document without a proper LilyPond installation (useful when
they only care for the content or for technical assistance).

MWE:

```tex
\documentclass{article}
\usepackage{lyluatex}
\begin{document}
\lilypond[program=Foo,showfailed]{ c' }
\end{document}
```