### PR TITLE
Fix mkdirs() handling of absolute tmpdir path

### DIFF
--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -197,7 +197,8 @@ end
 
 
 local function mkdirs(str)
-    local path = '.'
+    local path
+    if str:sub(1, 1) == '/' then path = '' else path = '.' end
     for dir in str:gmatch('([^%/]+)') do
         path = path .. '/' .. dir
         lfs.mkdir(path)


### PR DESCRIPTION
mkdirs() did *always* create a relative directory starting from the CWD.
When tmpdir is given an absolute path this resulted in a directory like
<compiled-file>/home/<user>/path/to/tmpdir being created.
The actual cache directory is considered properly, though.

The fix detects whether the given tmpdir is an absolute path.
At least on Unix.

**NOTE:** I don't think this works correctly on Windows. Is there the need for an improvement?