### PR TITLE
Factoring out local functions to lyluatex-lib module

### DIFF
--- a/lyluatex-lib.lua
+++ b/lyluatex-lib.lua
@@ -1,0 +1,200 @@
+-- luacheck: ignore ly log self luatexbase internalversion font fonts tex token kpse status
+local err, warn, info, log = luatexbase.provides_module({
+    name               = "lyluatex-lib",
+    version            = '1.0b',  --LYLUATEX_VERSION
+    date               = "2018/03/12",  --LYLUATEX_DATE
+    description        = "Module lyluatex-lib.",
+    author             = "The Gregorio Project  − (see Contributors.md)",
+    copyright          = "2015-2019 - jperon and others",
+    license            = "MIT",
+})
+
+local lib = {}
+lib.OPTIONS = {} -- will be a reference to the caller's lib.OPTIONS object
+lib.TEX_UNITS = {'bp', 'cc', 'cm', 'dd', 'in', 'mm', 'pc', 'pt', 'sp', 'em',
+'ex'}
+
+
+function lib.contains(table_var, value)
+    for k, v in pairs(table_var) do
+        if v == value then return k
+        elseif v == 'false' and value == false then return k
+        end
+    end
+end
+
+
+function lib.contains_key(table_var, key)
+    for k in pairs(table_var) do
+        if k == key then return true end
+    end
+end
+
+
+function lib.convert_unit(value)
+    if not value then return 0
+    elseif value == '' then return false
+    elseif value:match('\\') then
+        local n, u = value:match('^%d*%.?%d*'), value:match('%a+')
+        if n == '' then n = 1 end
+        return tonumber(n) * tex.dimen[u] / tex.sp("1pt")
+    else return ('%f'):format(tonumber(value) or tex.sp(value) / tex.sp("1pt"))
+    end
+end
+
+
+function lib.declare_package_options(options)
+    lib.OPTIONS = options
+    local exopt = ''
+    for k, v in pairs(options) do
+        tex.sprint(string.format([[
+\DeclareOptionX{%s}{\directlua{
+  ly.set_property('%s', '\luatexluaescapestring{#1}')
+}}%%
+]],
+            k, k
+        ))
+        exopt = exopt..k..'='..(v[1] or '')..','
+    end
+    tex.sprint([[\ExecuteOptionsX{]]..exopt..[[}%%]], [[\ProcessOptionsX]])
+end
+
+
+function lib.dirname(str) return str:gsub("(.*/)(.*)", "%1") or '' end
+
+
+local fontdata = fonts.hashes.identifiers
+function lib.fontinfo(id) return fontdata[id] or font.fonts[id] end
+
+
+function lib.is_alias() end
+
+
+function lib.is_dim(k, v)
+    if v == '' or v == false or tonumber(v) then return true end
+    local n, sl, u = v:match('^%d*%.?%d*'), v:match('\\'), v:match('%a+')
+    -- a value of number - backslash - length is a dimension
+    -- invalid input will be prevented in by the LaTeX parser already
+    if n and sl and u then return true end
+    if n and lib.contains(lib.TEX_UNITS, u) then return true end
+    err([[
+Unexpected value "%s" for dimension %s:
+should be either a number (for example "12"),
+a number with unit, without space ("12pt"),
+or a (multiplied) TeX length (".8\linewidth")
+]],
+        v, k
+    )
+end
+
+
+function lib.is_neg(k, _)
+    local _, i = k:find('^no')
+    return i and lib.contains_key(lib.OPTIONS, k:sub(i + 1))
+end
+
+
+function lib.max(a, b)
+    a, b = tonumber(a), tonumber(b)
+    if a > b then return a else return b end
+end
+
+
+function lib.min(a, b)
+    a, b = tonumber(a), tonumber(b)
+    if a < b then return a else return b end
+end
+
+
+function lib.mkdirs(str)
+    local path
+    if str:sub(1, 1) == '/' then path = '' else path = '.' end
+    for dir in str:gmatch('([^%/]+)') do
+        path = path .. '/' .. dir
+        lfs.mkdir(path)
+    end
+end
+
+
+function lib.orderedpairs(t)
+    local key
+    local i = 0
+    local orderedIndex = {}
+    for k in pairs(t) do table.insert(orderedIndex, k) end
+    table.sort(orderedIndex)
+    return function ()
+            i = i + 1
+            key = orderedIndex[i]
+            if key then return key, t[key] end
+        end
+end
+
+
+function lib.process_options(k, v)
+    if k == '' or k == 'noarg' then return end
+    if not lib.contains_key(lib.OPTIONS, k) then err('Unknown option: '..k) end
+    -- aliases
+    if lib.OPTIONS[k] and lib.OPTIONS[k][2] == lib.is_alias then
+        if lib.OPTIONS[k][1] == v then return
+        else k = lib.OPTIONS[k][1]
+        end
+    end
+    -- boolean
+    if v == 'false' then v = false end
+    -- negation (for example, noindent is the negation of indent)
+    if lib.is_neg(k) then
+        if v ~= nil and v ~= 'default' then
+            k = k:gsub('^no(.*)', '%1')
+            v = not v
+        else return
+        end
+    end
+    return k, v
+end
+
+
+function lib.range_parse(range, nsystems)
+    local num = tonumber(range)
+    if num then return {num} end
+    -- if nsystems is set, we have insert=systems
+    if nsystems ~= 0 and range:sub(-1) == '-' then range = range..nsystems end
+    if not (range == '' or range:match('^%d+%s*-%s*%d*$')) then
+        warn([[
+Invalid value '%s' for item
+in list of page ranges. Possible entries:
+- Single number
+- Range (M-N, N-M or N-)
+This item will be skipped!
+]],
+            range
+        )
+        return
+    end
+    local result = {}
+    local from, to = tonumber(range:match('^%d+')), tonumber(range:match('%d+$'))
+    if to then
+        local dir
+        if from <= to then dir = 1 else dir = -1 end
+        for i = from, to, dir do table.insert(result, i) end
+        return result
+    else return {range}  -- N- with insert=fullpage
+    end
+end
+
+
+function lib.readlinematching(s, f)
+    if f then
+        local result = ''
+        while result and not result:find(s) do result = f:read() end
+        f:close()
+        return result
+    end
+end
+
+
+function lib.splitext(str, ext)
+  return str:match('(.*)%.'..ext..'$') or str
+end
+
+
+return lib

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -9,6 +9,8 @@ local err, warn, info, log = luatexbase.provides_module({
     license            = "MIT",
 })
 
+local lib = require(kpse.find_file("lyluatex-lib.lua") or "lyluatex-lib.lua")
+
 local md5 = require 'md5'
 local lfs = require 'lfs'
 
@@ -20,7 +22,6 @@ local ly = {
 local Score = {}
 
 local FILELIST
-local OPTIONS = {}
 local DIM_OPTIONS = {
     'extra-bottom-margin',
     'extra-top-margin',
@@ -60,7 +61,6 @@ local MXML_OPTIONS = {
     'verbose',
 }
 local TEXINFO_OPTIONS = {'doctitle', 'nogettext', 'texidoc'}
-local TEX_UNITS = {'bp', 'cc', 'cm', 'dd', 'in', 'mm', 'pc', 'pt', 'sp', 'em', 'ex'}
 local LY_HEAD = [[
 %%File header
 \version "<<<version>>>"
@@ -106,37 +106,6 @@ local function debug(...)
 end
 
 
-local function contains(table_var, value)
-    for k, v in pairs(table_var) do
-        if v == value then return k
-        elseif v == 'false' and value == false then return k
-        end
-    end
-end
-
-
-local function contains_key(table_var, key)
-    for k in pairs(table_var) do
-        if k == key then return true end
-    end
-end
-
-
-local function convert_unit(value)
-    if not value then return 0
-    elseif value == '' then return false
-    elseif value:match('\\') then
-        local n, u = value:match('^%d*%.?%d*'), value:match('%a+')
-        if n == '' then n = 1 end
-        return tonumber(n) * tex.dimen[u] / tex.sp("1pt")
-    else return ('%f'):format(tonumber(value) or tex.sp(value) / tex.sp("1pt"))
-    end
-end
-
-
-local function dirname(str) return str:gsub("(.*/)(.*)", "%1") or '' end
-
-
 local function extract_includepaths(includepaths)
     includepaths = includepaths:explode(',')
     local cfd = Score.currfiledir:gsub('^$', './')
@@ -149,12 +118,8 @@ local function extract_includepaths(includepaths)
 end
 
 
-local fontdata = fonts.hashes.identifiers
-local function fontinfo(id) return fontdata[id] or font.fonts[id] end
-
-
 local function font_default_staffsize()
-    return fontinfo(font.current()).size/39321.6
+    return lib.fontinfo(font.current()).size/39321.6
 end
 
 
@@ -296,9 +261,6 @@ local function set_lyscore(score)
 end
 
 
-local function splitext(str, ext) return str:match('(.*)%.'..ext..'$') or str end
-
-
 --[[ ================ Bounding box calculations =========================== --]]
 
 local bbox = {}
@@ -308,13 +270,13 @@ end
 
 function bbox.calc(x_1, x_2, y_1, y_2, line_width)
     local bb = {
-        ['protrusion'] = -convert_unit(("%fbp"):format(x_1)),
-        ['r_protrusion'] = convert_unit(("%fbp"):format(x_2)) - line_width,
-        ['width'] = convert_unit(("%fbp"):format(x_2))
+        ['protrusion'] = -lib.convert_unit(("%fbp"):format(x_1)),
+        ['r_protrusion'] = lib.convert_unit(("%fbp"):format(x_2)) - line_width,
+        ['width'] = lib.convert_unit(("%fbp"):format(x_2))
     }
     --FIX #192: height is only calculated if really needed, to prevent errors with huge scores.
     function bb.__index(_, k)
-        if k == 'height' then return convert_unit(("%fbp"):format(y_2)) - convert_unit(("%fbp"):format(y_1)) end
+        if k == 'height' then return lib.convert_unit(("%fbp"):format(y_2)) - lib.convert_unit(("%fbp"):format(y_1)) end
     end
     setmetatable(bb, bb)
     return bb
@@ -322,11 +284,11 @@ end
 
 function bbox.parse(filename, line_width)
     -- get BoundingBox from EPS file
-    local bbline = readlinematching('^%%%%BoundingBox', io.open(filename..'.eps', 'r'))
+    local bbline = lib.readlinematching('^%%%%BoundingBox', io.open(filename..'.eps', 'r'))
     if not bbline then return end
     local x_1, y_1, x_2, y_2 = bbline:match('(%--%d+)%s(%--%d+)%s(%--%d+)%s(%--%d+)')
     -- try to get HiResBoundingBox from PDF (if 'gs' works)
-    bbline = readlinematching(
+    bbline = lib.readlinematching(
         '^%%%%HiResBoundingBox',
         io.popen('gs -sDEVICE=bbox -q -dBATCH -dNOPAUSE '..filename..'.pdf 2>&1', 'r')
     )
@@ -384,8 +346,8 @@ end
 function latex.includeinline(pdfname, height, valign, hpadding, voffset)
     local v_base
     if valign == 'bottom' then v_base = 0
-    elseif valign == 'top' then v_base = convert_unit('1em') - height
-    else v_base = (convert_unit('1em') - height) / 2
+    elseif valign == 'top' then v_base = lib.convert_unit('1em') - height
+    else v_base = (lib.convert_unit('1em') - height) / 2
     end
     tex.sprint(
         string.format(
@@ -524,7 +486,7 @@ function Score:calc_properties()
     end
     -- dimensions that can be given by LaTeX
     for _, dimension in pairs(DIM_OPTIONS) do
-        self[dimension] = convert_unit(self[dimension])
+        self[dimension] = lib.convert_unit(self[dimension])
     end
     self['max-left-protrusion'] = self['max-left-protrusion'] or self['max-protrusion']
     self['max-right-protrusion'] = self['max-right-protrusion'] or self['max-protrusion']
@@ -556,7 +518,7 @@ function Score:calc_range()
     local result = tonumber(printonly) and {tonumber(printonly)} or {}
     if not result[1] then
         for _, r in pairs(printonly:explode(',')) do
-            local range = range_parse(r:gsub('^%s', ''):gsub('%s$', ''), nsystems)
+            local range = lib.range_parse(r:gsub('^%s', ''):gsub('%s$', ''), nsystems)
             if range then
                 for _, v in pairs(range) do table.insert(result, v) end
             end
@@ -565,14 +527,14 @@ function Score:calc_range()
     local rm_result = tonumber(donotprint) and {tonumber(donotprint)} or {}
     if not rm_result[1] then
         for _, r in pairs(donotprint:explode(',')) do
-            local range = range_parse(r:gsub('^%s', ''):gsub('%s$', ''), nsystems)
+            local range = lib.range_parse(r:gsub('^%s', ''):gsub('%s$', ''), nsystems)
             if range then
                 for _, v in pairs(range) do table.insert(rm_result, v) end
             end
         end
     end
     for _, v in pairs(rm_result) do
-        local k = contains(result, v)
+        local k = lib.contains(result, v)
         if k then table.remove(result, k) end
     end
     return result
@@ -678,7 +640,7 @@ function Score:check_indent(lp)
         if lp.shorten > 0 then
             if not self.indent or self.indent == 0 then
                 self.indent = lp.overflow_left
-                lp.shorten = max(lp.shorten - lp.overflow_left, 0)
+                lp.shorten = lib.max(lp.shorten - lp.overflow_left, 0)
             else
                 self.indent = max(self.indent - lp.overflow_left, 0)
             end
@@ -728,13 +690,13 @@ end
 
 function Score:check_properties()
     local unexpected = false
-    for k, _ in orderedpairs(OPTIONS) do
+    for k, _ in lib.orderedpairs(lib.OPTIONS) do
         if self[k] == 'default' then
-            self[k] = OPTIONS[k][1] or nil
+            self[k] = lib.OPTIONS[k][1] or nil
             unexpected = not self[k]
         end
-        if not contains(OPTIONS[k], self[k]) and OPTIONS[k][2] then
-            if type(OPTIONS[k][2]) == 'function' then OPTIONS[k][2](k, self[k])
+        if not lib.contains(lib.OPTIONS[k], self[k]) and lib.OPTIONS[k][2] then
+            if type(lib.OPTIONS[k][2]) == 'function' then lib.OPTIONS[k][2](k, self[k])
             else unexpected = true
             end
         end
@@ -743,7 +705,7 @@ function Score:check_properties()
 Unexpected value "%s" for option %s:
 authorized values are "%s"
 ]],
-                self[k], k, table.concat(OPTIONS[k], ', ')
+                self[k], k, table.concat(lib.OPTIONS[k], ', ')
             )
         end
     end
@@ -777,10 +739,10 @@ function Score:check_protrusion(bbox_func)
     -- line_props lp
     local lp = {}
     -- Determine offset due to left protrusion
-    lp.overflow_left = max(bb.protrusion - math.floor(self['max-left-protrusion']), 0)
+    lp.overflow_left = lib.max(bb.protrusion - math.floor(self['max-left-protrusion']), 0)
     self.protrusion_left = lp.overflow_left - bb.protrusion
     -- Determine further line properties
-    lp.stave_extent = lp.overflow_left + min(self['line-width'], bb.width)
+    lp.stave_extent = lp.overflow_left + lib.min(self['line-width'], bb.width)
     lp.available = self.original_lw + self['max-right-protrusion']
     lp.total_extent = lp.stave_extent + bb.r_protrusion
     -- Check if stafflines protrude into the right margin after offsetting
@@ -789,7 +751,7 @@ function Score:check_protrusion(bbox_func)
     -- present
     lp.stave_overflow_right = max(lp.stave_extent - self.original_lw, 0)
     -- Check if image as a whole protrudes over max-right-protrusion
-    lp.overflow_right = max(lp.total_extent - lp.available, 0)
+    lp.overflow_right = lib.max(lp.total_extent - lp.available, 0)
     lp.shorten = max(lp.stave_overflow_right, lp.overflow_right)
     lp.changed_indent = false
     self:check_indent(lp, bb)
@@ -866,7 +828,7 @@ function Score:flatten_content(ly_code)
     ly_code = ly_code:gsub('%%', '#')
     local f
     local includepaths = self.includepaths..','..self.tmpdir
-    if self.input_file then includepaths = self.includepaths..','..dirname(self.input_file) end
+    if self.input_file then includepaths = self.includepaths..','..lib.dirname(self.input_file) end
     for iline in ly_code:gmatch('\\include%s*"[^"]*"') do
         f = io.open(locate(iline:match('\\include%s*"([^"]*)"'), includepaths, '.ly') or '')
         if f then
@@ -911,7 +873,7 @@ function Score:lilypond_cmd(ly_code)
         "-dno-delete-intermediate-files "
     if self['optimize-pdf'] and self:lilypond_has_TeXGS() then cmd = cmd.."-O TeX-GS " end
     if self.input_file then
-        cmd = cmd..'-I "'..dirname(self.input_file):gsub('^%./', lfs.currentdir()..'/')..'" '
+        cmd = cmd..'-I "'..lib.dirname(self.input_file):gsub('^%./', lfs.currentdir()..'/')..'" '
     end
     for _, dir in ipairs(extract_includepaths(self.includepaths)) do
         cmd = cmd..'-I "'..dir:gsub('^%./', lfs.currentdir()..'/')..'" '
@@ -922,11 +884,11 @@ function Score:lilypond_cmd(ly_code)
 end
 
 function Score:lilypond_has_TeXGS()
-    return readlinematching('TeX%-GS', io.popen('"'..self.program..'" --help', 'r'))
+    return lib.readlinematching('TeX%-GS', io.popen('"'..self.program..'" --help', 'r'))
 end
 
 function Score:lilypond_version(number)
-    local result = readlinematching('GNU LilyPond', io.popen('"'..self.program..'" --version', 'r'))
+    local result = lib.readlinematching('GNU LilyPond', io.popen('"'..self.program..'" --version', 'r'))
     if result then
         if number then return result:match('%d+%.%d+%.?%d*')
         else
@@ -1149,8 +1111,8 @@ end
 
 function Score:output_filename()
     local properties = ''
-    for k, _ in orderedpairs(OPTIONS) do
-        if (not contains(HASHIGNORE, k)) and self[k] and type(self[k]) ~= 'function' then
+    for k, _ in lib.orderedpairs(lib.OPTIONS) do
+        if (not lib.contains(HASHIGNORE, k)) and self[k] and type(self[k]) ~= 'function' then
             properties = properties..'\n'..k..'\t'..self[k]
         end
     end
@@ -1216,7 +1178,7 @@ end
 
 function Score:run_lilypond(ly_code)
     if self:is_compiled() then return end
-    mkdirs(dirname(self.output))
+    lib.mkdirs(lib.dirname(self.output))
     local p = io.popen(self:lilypond_cmd(ly_code))
     if self.debug then
         local f = io.open(self.output..".log", 'w')
@@ -1229,15 +1191,15 @@ end
 
 function Score:tex_margin_bottom()
     self._tex_margin_bottom = self._tex_margin_bottom or
-        convert_unit(tex.dimen.paperheight..'sp')
+        lib.convert_unit(tex.dimen.paperheight..'sp')
         - self:tex_margin_top()
-        - convert_unit(tex.dimen.textheight..'sp')
+        - lib.convert_unit(tex.dimen.textheight..'sp')
     return self._tex_margin_bottom
 end
 
 function Score:tex_margin_inner()
     self._tex_margin_inner = self._tex_margin_inner or
-        convert_unit((
+        lib.convert_unit((
           tex.sp('1in') + tex.dimen.oddsidemargin + tex.dimen.hoffset
         )..'sp')
     return self._tex_margin_inner
@@ -1245,7 +1207,7 @@ end
 
 function Score:tex_margin_outer()
     self._tex_margin_outer = self._tex_margin_outer or
-        convert_unit((tex.dimen.paperwidth - tex.dimen.textwidth)..'sp')
+        lib.convert_unit((tex.dimen.paperwidth - tex.dimen.textwidth)..'sp')
         - self:tex_margin_inner()
     return self._tex_margin_outer
 end
@@ -1264,7 +1226,7 @@ end
 
 function Score:tex_margin_top()
     self._tex_margin_top = self._tex_margin_top or
-        convert_unit((
+        lib.convert_unit((
             tex.sp('1in') + tex.dimen.voffset + tex.dimen.topmargin
             + tex.dimen.headheight + tex.dimen.headsep
         )..'sp')
@@ -1368,25 +1330,14 @@ end
 
 
 function ly.declare_package_options(options)
-    OPTIONS = options
-    local exopt = ''
-    for k, v in pairs(options) do
-        tex.sprint(string.format([[
-\DeclareOptionX{%s}{\directlua{
-  ly.set_property('%s', '\luatexluaescapestring{#1}')
-}}%%
-]],
-            k, k
-        ))
-        exopt = exopt..k..'='..(v[1] or '')..','
-    end
-    tex.sprint([[\ExecuteOptionsX{]]..exopt..[[}%%]], [[\ProcessOptionsX]])
+    lib.declare_package_options(options)
 end
+
 
 function ly.make_list_file()
     local tmpdir = ly.get_option('tmpdir')
-    mkdirs(tmpdir)
-    FILELIST = tmpdir..'/'..splitext(status.log_name, 'log')..'.list'
+    lib.mkdirs(tmpdir)
+    FILELIST = tmpdir..'/'..lib.splitext(status.log_name, 'log')..'.list'
     os.remove(FILELIST)
 end
 
@@ -1445,37 +1396,25 @@ end
 
 
 function ly.get_font_family(font_id)
-    return fontinfo(font_id).shared.rawdata.metadata['familyname']
+    return lib.fontinfo(font_id).shared.rawdata.metadata['familyname']
 end
 
 
 function ly.get_option(opt) return Score[opt] end
 
 
-function ly.is_alias() end
+function ly.is_alias()
+    return lib.is_alias()
+end
 
 
 function ly.is_dim(k, v)
-    if v == '' or v == false or tonumber(v) then return true end
-    local n, sl, u = v:match('^%d*%.?%d*'), v:match('\\'), v:match('%a+')
-    -- a value of number - backslash - length is a dimension
-    -- invalid input will be prevented in by the LaTeX parser already
-    if n and sl and u then return true end
-    if n and contains(TEX_UNITS, u) then return true end
-    err([[
-Unexpected value "%s" for dimension %s:
-should be either a number (for example "12"),
-a number with unit, without space ("12pt"),
-or a (multiplied) TeX length (".8\linewidth")
-]],
-        v, k
-    )
+    lib.is_dim(k, v)
 end
 
 
 function ly.is_neg(k, _)
-    local _, i = k:find('^no')
-    return i and contains_key(OPTIONS, k:sub(i + 1))
+    return lib.is_neg(k, _)
 end
 
 
@@ -1514,7 +1453,7 @@ function ly.set_local_options(opts)
                 while v:sub(-1) ~= '}' do v = v..','..next_opt() end
                 v = v:sub(2, -2)  -- remove { }
             end
-            k, v = process_options(k:gsub('^%s', ''), v:gsub('^%s', ''))
+            k, v = lib.process_options(k:gsub('^%s', ''), v:gsub('^%s', ''))
             if k then
                 if options[k] then err('Option %s is set two times for the same score.', k)
                 else options[k] = v
@@ -1526,7 +1465,7 @@ function ly.set_local_options(opts)
 end
 
 function ly.set_property(k, v)
-    k, v = process_options(k, v)
+    k, v = lib.process_options(k, v)
     if k then Score[k] = v end
 end
 

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -184,28 +184,6 @@ local function orderedpairs(t)
 end
 
 
-local function process_options(k, v)
-    if k == '' or k == 'noarg' then return end
-    if not contains_key(OPTIONS, k) then err('Unknown option: '..k) end
-    -- aliases
-    if OPTIONS[k] and OPTIONS[k][2] == ly.is_alias then
-        if OPTIONS[k][1] == v then return
-        else k = OPTIONS[k][1]
-        end
-    end
-    -- boolean
-    if v == 'false' then v = false end
-    -- negation (for example, noindent is the negation of indent)
-    if ly.is_neg(k) then
-        if v ~= nil and v ~= 'default' then
-            k = k:gsub('^no(.*)', '%1')
-            v = not v
-        else return
-        end
-    end
-    return k, v
-end
-
 
 local function range_parse(range, nsystems)
     local num = tonumber(range)

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -21,6 +21,7 @@ local ly = {
 }
 local Score = {}
 
+local OPTIONS = {}
 local FILELIST
 local DIM_OPTIONS = {
     'extra-bottom-margin',
@@ -668,13 +669,13 @@ end
 
 function Score:check_properties()
     local unexpected = false
-    for k, _ in lib.orderedpairs(lib.OPTIONS) do
+    for k, _ in lib.orderedpairs(OPTIONS) do
         if self[k] == 'default' then
-            self[k] = lib.OPTIONS[k][1] or nil
+            self[k] = OPTIONS[k][1] or nil
             unexpected = not self[k]
         end
-        if not lib.contains(lib.OPTIONS[k], self[k]) and lib.OPTIONS[k][2] then
-            if type(lib.OPTIONS[k][2]) == 'function' then lib.OPTIONS[k][2](k, self[k])
+        if not lib.contains(OPTIONS[k], self[k]) and OPTIONS[k][2] then
+            if type(OPTIONS[k][2]) == 'function' then OPTIONS[k][2](k, self[k])
             else unexpected = true
             end
         end
@@ -683,7 +684,7 @@ function Score:check_properties()
 Unexpected value "%s" for option %s:
 authorized values are "%s"
 ]],
-                self[k], k, table.concat(lib.OPTIONS[k], ', ')
+                self[k], k, table.concat(OPTIONS[k], ', ')
             )
         end
     end
@@ -1089,7 +1090,7 @@ end
 
 function Score:output_filename()
     local properties = ''
-    for k, _ in lib.orderedpairs(lib.OPTIONS) do
+    for k, _ in lib.orderedpairs(OPTIONS) do
         if (not lib.contains(HASHIGNORE, k)) and self[k] and type(self[k]) ~= 'function' then
             properties = properties..'\n'..k..'\t'..self[k]
         end
@@ -1308,7 +1309,8 @@ end
 
 
 function ly.declare_package_options(options)
-    lib.declare_package_options(options)
+    OPTIONS = options
+    lib.declare_package_options(options, 'ly')
 end
 
 
@@ -1392,7 +1394,7 @@ end
 
 
 function ly.is_neg(k, _)
-    return lib.is_neg(k, _)
+    return lib.is_neg(OPTIONS, k)
 end
 
 
@@ -1431,7 +1433,7 @@ function ly.set_local_options(opts)
                 while v:sub(-1) ~= '}' do v = v..','..next_opt() end
                 v = v:sub(2, -2)  -- remove { }
             end
-            k, v = lib.process_options(k:gsub('^%s', ''), v:gsub('^%s', ''))
+            k, v = lib.process_options(OPTIONS, k:gsub('^%s', ''), v:gsub('^%s', ''))
             if k then
                 if options[k] then err('Option %s is set two times for the same score.', k)
                 else options[k] = v
@@ -1443,7 +1445,7 @@ function ly.set_local_options(opts)
 end
 
 function ly.set_property(k, v)
-    k, v = lib.process_options(k, v)
+    k, v = lib.process_options(OPTIONS, k, v)
     if k then Score[k] = v end
 end
 


### PR DESCRIPTION
This is an initial commit at factoring out commonly usable functionality to a separate module. For now I have moved all the local functions to a new file `lyluatex-lib.lua` that are unrelated to `lyluatex`'s actual work.

I think there can be more code to be moved and reused from other packages/modules. One thing, though: I have the impression that the code factored out is the code that is totally unrelated to LilyPond scores but rather concerned with managing a Lua-based LaTeX package. If that's correct (I'm not too sure about my perception of these things) it might be something to consider to factor this out to a completely independent module/package that can be used from arbitrary packages (I think I would love to use the option handling functionality from arbitrary packages without including `lyluatex` (but maybe that's already possible like it is, simply assuming the package is *installed*?).

I'm not sure if this Pull Request is intended to already be merged. I opened it to request your feedback @jperon, but of course you can merge it if you want. I have tested it with `make clean make manual`, so I assume there are no errors in it.

If you think it is OK to move in that direction I would reorganize the file to separate the generic tools from those for option/package management.

NOTE: This commit *includes* the change made in #241, so basically it closes #241 (that last mention is to see if the autoclose feature works)