### PR TITLE
lyluatex-options

### DIFF
--- a/lyluatex-lib.lua
+++ b/lyluatex-lib.lua
@@ -13,8 +13,14 @@ local lib = {}
 lib.TEX_UNITS = {'bp', 'cc', 'cm', 'dd', 'in', 'mm', 'pc', 'pt', 'sp', 'em',
 'ex'}
 
+-------------------------
+-- General tool functions
 
 function lib.contains(table_var, value)
+--[[
+  Returns the key if the given table contains the given value, or nil.
+  A value of 'false' (string) is considered equal to false (Boolean).
+--]]
     for k, v in pairs(table_var) do
         if v == value then return k
         elseif v == 'false' and value == false then return k
@@ -24,6 +30,7 @@ end
 
 
 function lib.contains_key(table_var, key)
+-- Returs true if the given key is present in the table, nil otherwise.
     for k in pairs(table_var) do
         if k == key then return true end
     end
@@ -31,6 +38,10 @@ end
 
 
 function lib.convert_unit(value)
+--[[
+  Convert a LaTeX unit, if possible.
+  TODO: Understand what this *really* does, what is accepted and returned.
+--]]
     if not value then return 0
     elseif value == '' then return false
     elseif value:match('\\') then
@@ -41,6 +52,29 @@ function lib.convert_unit(value)
     end
 end
 
+
+function lib.dirname(str)
+--[[
+  Return the left part of a string up to and including the last slash.
+  If no slash is present (no path components) return an empty string
+--]]
+    return str:gsub("(.*/)(.*)", "%1") or ''
+end
+
+
+local fontdata = fonts.hashes.identifiers
+function lib.fontinfo(id) 
+--[[
+  Return a LuaTeX font object based on the given ID
+--]]
+    return fontdata[id] or font.fonts[id]
+end
+
+
+-----------------------------------------------------------
+-- Functionality for handling package and local options
+-- An options table has to be stored in the calling module
+-- and passed into the functions.
 
 function lib.declare_package_options(options, obj_name)
     local exopt = ''
@@ -56,13 +90,6 @@ function lib.declare_package_options(options, obj_name)
     end
     tex.sprint([[\ExecuteOptionsX{]]..exopt..[[}%%]], [[\ProcessOptionsX]])
 end
-
-
-function lib.dirname(str) return str:gsub("(.*/)(.*)", "%1") or '' end
-
-
-local fontdata = fonts.hashes.identifiers
-function lib.fontinfo(id) return fontdata[id] or font.fonts[id] end
 
 
 function lib.is_alias() end

--- a/lyluatex-options.lua
+++ b/lyluatex-options.lua
@@ -244,11 +244,11 @@ function optlib.validate_option(prefix, key, options_obj)
 --]]
     local package_opts = optlib.get_declarations(prefix)
     local options = options_obj or optlib.get_options(prefix)
-
+    local unexpected
     if options[key] == 'default' then
         -- Replace 'default' with an actual value
-        options[key] = package_opts[key][1] or nil
-        unexpected = not options[key]
+        options[key] = package_opts[key][1]
+        unexpected = options[key] == nil
     end
     if not lib.contains(package_opts[key], options[key]) and package_opts[key][2] then
         -- option value is not in the array of accepted values

--- a/lyluatex-options.lua
+++ b/lyluatex-options.lua
@@ -60,7 +60,7 @@ function optlib.is_neg(options, k)
 end
 
 
-function optlib.process_options(options, k, v)
+function optlib.sanitize_option(options, k, v)
     if k == '' or k == 'noarg' then return end
     if not lib.contains_key(options, k) then err('Unknown option: '..k) end
     -- aliases

--- a/lyluatex-options.lua
+++ b/lyluatex-options.lua
@@ -1,0 +1,85 @@
+-- luacheck: ignore ly log self luatexbase internalversion font fonts tex token kpse status
+local err, warn, info, log = luatexbase.provides_module({
+    name               = "lyluatex-options",
+    version            = '1.0b',  --LYLUATEX_VERSION
+    date               = "2018/03/12",  --LYLUATEX_DATE
+    description        = "Module lyluatex-options.",
+    author             = "The Gregorio Project  − (see Contributors.md)",
+    copyright          = "2015-2019 - jperon and others",
+    license            = "MIT",
+})
+
+local optlib = {}
+local lib = require(kpse.find_file("lyluatex-lib.lua") or "lyluatex-lib.lua")
+
+-----------------------------------------------------------
+-- Functionality for handling package and local options
+-- An options table has to be stored in the calling module
+-- and passed into the functions.
+
+function optlib.declare_package_options(options, obj_name)
+    local exopt = ''
+    for k, v in pairs(options) do
+        tex.sprint(string.format([[
+\DeclareOptionX{%s}{\directlua{
+  %s.set_property('%s', '\luatexluaescapestring{#1}')
+}}%%
+]],
+            k, obj_name, k
+        ))
+        exopt = exopt..k..'='..(v[1] or '')..','
+    end
+    tex.sprint([[\ExecuteOptionsX{]]..exopt..[[}%%]], [[\ProcessOptionsX]])
+end
+
+
+function optlib.is_alias() end
+
+
+function optlib.is_dim(k, v)
+    if v == '' or v == false or tonumber(v) then return true end
+    local n, sl, u = v:match('^%d*%.?%d*'), v:match('\\'), v:match('%a+')
+    -- a value of number - backslash - length is a dimension
+    -- invalid input will be prevented in by the LaTeX parser already
+    if n and sl and u then return true end
+    if n and lib.contains(lib.TEX_UNITS, u) then return true end
+    err([[
+Unexpected value "%s" for dimension %s:
+should be either a number (for example "12"),
+a number with unit, without space ("12pt"),
+or a (multiplied) TeX length (".8\linewidth")
+]],
+        v, k
+    )
+end
+
+
+function optlib.is_neg(options, k)
+    local _, i = k:find('^no')
+    return i and lib.contains_key(options, k:sub(i + 1))
+end
+
+
+function optlib.process_options(options, k, v)
+    if k == '' or k == 'noarg' then return end
+    if not lib.contains_key(options, k) then err('Unknown option: '..k) end
+    -- aliases
+    if options[k] and options[k][2] == optlib.is_alias then
+        if options[k][1] == v then return
+        else k = options[k] end
+    end
+    -- boolean
+    if v == 'false' then v = false end
+    -- negation (for example, noindent is the negation of indent)
+    if optlib.is_neg(options, k) then
+        if v ~= nil and v ~= 'default' then
+            k = k:gsub('^no(.*)', '%1')
+            v = not v
+        else return
+        end
+    end
+    return k, v
+end
+
+
+return optlib

--- a/lyluatex-options.lua
+++ b/lyluatex-options.lua
@@ -120,4 +120,33 @@ function optlib.sanitize_option(options, k, v)
 end
 
 
+function optlib.set_local_options(global_opts, local_opts)
+--[[
+    Parse the given local_opts (options passed to a command/environment),
+    sanitize them and merge them into the global_opts, so local
+    options supersede global ones without changing them.
+    Return a table with the effective options to be used for the given
+    element.
+--]]
+    local options = {}
+    local next_opt = local_opts:gmatch('([^,]+)')  -- iterator over options
+    for opt in next_opt do
+        local k, v = opt:match('([^=]+)=?(.*)')
+        if k then
+            if v and v:sub(1, 1) == '{' then  -- handle keys with {multiple, values}
+                while v:sub(-1) ~= '}' do v = v..','..next_opt() end
+                v = v:sub(2, -2)  -- remove { }
+            end
+            k, v = optlib.sanitize_option(global_opts, k:gsub('^%s', ''), v:gsub('^%s', ''))
+            if k then
+                if options[k] then err('Option %s is set two times for the same score.', k)
+                else options[k] = v
+                end
+            end
+        end
+    end
+    return options
+end
+
+
 return optlib

--- a/lyluatex-options.lua
+++ b/lyluatex-options.lua
@@ -183,6 +183,14 @@ function optlib.is_num(_, _, v)
 end
 
 
+function optlib.is_str(_, _, v)
+--[[
+    Type check for string options
+--]]
+    return type(v) == 'string'
+end
+
+
 function optlib.sanitize_option(prefix, k, v)
 --[[
     Check and (if necessary) adjust the value of a given option.

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -1211,7 +1211,6 @@ function ly.attach_Score_table()
         _k, _v = optlib.sanitize_option('ly', k, v)
         if _k then Score[_k] = _v end
     end
-    options = Score
 end
 
 

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -625,27 +625,7 @@ function Score:check_indent(lp)
 end
 
 function Score:check_properties()
-    local unexpected = false
-    local options = optlib.get_options('ly')
-    for k, _ in lib.orderedpairs(options) do
-        if self[k] == 'default' then
-            self[k] = options[k][1] or nil
-            unexpected = not self[k]
-        end
-        if not lib.contains(options[k], self[k]) and options[k][2] then
-            if type(options[k][2]) == 'function' then options[k][2](k, self[k])
-            else unexpected = true
-            end
-        end
-        if unexpected then
-            err([[
-Unexpected value "%s" for option %s:
-authorized values are "%s"
-]],
-                self[k], k, table.concat(options[k], ', ')
-            )
-        end
-    end
+    optlib.validate_options('ly', self)
     for _, k in pairs(TEXINFO_OPTIONS) do
         if self[k] then info([[Option %s is specific to Texinfo: ignoring it.]], k) end
     end

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -1390,7 +1390,7 @@ function ly.set_local_options(opts)
                 while v:sub(-1) ~= '}' do v = v..','..next_opt() end
                 v = v:sub(2, -2)  -- remove { }
             end
-            k, v = optlib.process_options(OPTIONS, k:gsub('^%s', ''), v:gsub('^%s', ''))
+            k, v = optlib.sanitize_option(OPTIONS, k:gsub('^%s', ''), v:gsub('^%s', ''))
             if k then
                 if options[k] then err('Option %s is set two times for the same score.', k)
                 else options[k] = v
@@ -1402,7 +1402,7 @@ function ly.set_local_options(opts)
 end
 
 function ly.set_property(k, v)
-    k, v = optlib.process_options(OPTIONS, k, v)
+    k, v = optlib.sanitize_option(OPTIONS, k, v)
     if k then Score[k] = v end
 end
 

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -150,81 +150,6 @@ local function locate(file, includepaths, ext)
 end
 
 
-local function max(a, b)
-    a, b = tonumber(a), tonumber(b)
-    if a > b then return a else return b end
-end
-
-
-local function min(a, b)
-    a, b = tonumber(a), tonumber(b)
-    if a < b then return a else return b end
-end
-
-
-local function mkdirs(str)
-    local path = '.'
-    for dir in str:gmatch('([^%/]+)') do
-        path = path .. '/' .. dir
-        lfs.mkdir(path)
-    end
-end
-
-
-local function orderedpairs(t)
-    local key
-    local i = 0
-    local orderedIndex = {}
-    for k in pairs(t) do table.insert(orderedIndex, k) end
-    table.sort(orderedIndex)
-    return function ()
-            i = i + 1
-            key = orderedIndex[i]
-            if key then return key, t[key] end
-        end
-end
-
-
-
-local function range_parse(range, nsystems)
-    local num = tonumber(range)
-    if num then return {num} end
-    -- if nsystems is set, we have insert=systems
-    if nsystems ~= 0 and range:sub(-1) == '-' then range = range..nsystems end
-    if not (range == '' or range:match('^%d+%s*-%s*%d*$')) then
-        warn([[
-Invalid value '%s' for item
-in list of page ranges. Possible entries:
-- Single number
-- Range (M-N, N-M or N-)
-This item will be skipped!
-]],
-            range
-        )
-        return
-    end
-    local result = {}
-    local from, to = tonumber(range:match('^%d+')), tonumber(range:match('%d+$'))
-    if to then
-        local dir
-        if from <= to then dir = 1 else dir = -1 end
-        for i = from, to, dir do table.insert(result, i) end
-        return result
-    else return {range}  -- N- with insert=fullpage
-    end
-end
-
-
-local function readlinematching(s, f)
-    if f then
-        local result = ''
-        while result and not result:find(s) do result = f:read() end
-        f:close()
-        return result
-    end
-end
-
-
 local function set_lyscore(score)
     ly.score = score
     ly.score.nsystems = ly.score:count_systems()
@@ -621,7 +546,7 @@ function Score:check_indent(lp)
                 self.indent = lp.overflow_left
                 lp.shorten = lib.max(lp.shorten - lp.overflow_left, 0)
             else
-                self.indent = max(self.indent - lp.overflow_left, 0)
+                self.indent = lib.max(self.indent - lp.overflow_left, 0)
             end
             lp.changed_indent = true
         end
@@ -728,10 +653,10 @@ function Score:check_protrusion(bbox_func)
     -- Note: we can't *reliably* determine this with ragged one-system scores,
     -- possibly resulting in unnecessarily short lines when right protrusion is
     -- present
-    lp.stave_overflow_right = max(lp.stave_extent - self.original_lw, 0)
+    lp.stave_overflow_right = lib.max(lp.stave_extent - self.original_lw, 0)
     -- Check if image as a whole protrudes over max-right-protrusion
     lp.overflow_right = lib.max(lp.total_extent - lp.available, 0)
-    lp.shorten = max(lp.stave_overflow_right, lp.overflow_right)
+    lp.shorten = lib.max(lp.stave_overflow_right, lp.overflow_right)
     lp.changed_indent = false
     self:check_indent(lp, bb)
     if lp.shorten > 0 or lp.changed_indent then

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -626,13 +626,14 @@ end
 
 function Score:check_properties()
     local unexpected = false
-    for k, _ in lib.orderedpairs(OPTIONS) do
+    local options = optlib.get_options('ly')
+    for k, _ in lib.orderedpairs(options) do
         if self[k] == 'default' then
-            self[k] = OPTIONS[k][1] or nil
+            self[k] = options[k][1] or nil
             unexpected = not self[k]
         end
-        if not lib.contains(OPTIONS[k], self[k]) and OPTIONS[k][2] then
-            if type(OPTIONS[k][2]) == 'function' then OPTIONS[k][2](k, self[k])
+        if not lib.contains(options[k], self[k]) and options[k][2] then
+            if type(options[k][2]) == 'function' then options[k][2](k, self[k])
             else unexpected = true
             end
         end
@@ -641,7 +642,7 @@ function Score:check_properties()
 Unexpected value "%s" for option %s:
 authorized values are "%s"
 ]],
-                self[k], k, table.concat(OPTIONS[k], ', ')
+                self[k], k, table.concat(options[k], ', ')
             )
         end
     end
@@ -1047,7 +1048,7 @@ end
 
 function Score:output_filename()
     local properties = ''
-    for k, _ in lib.orderedpairs(OPTIONS) do
+    for k, _ in lib.orderedpairs(optlib.get_options('ly')) do
         if (not lib.contains(HASHIGNORE, k)) and self[k] and type(self[k]) ~= 'function' then
             properties = properties..'\n'..k..'\t'..self[k]
         end
@@ -1265,12 +1266,6 @@ Transcript written on %s.log.
 end
 
 
-function ly.declare_package_options(options)
-    OPTIONS = options
-    optlib.declare_package_options(options, 'ly')
-end
-
-
 function ly.make_list_file()
     local tmpdir = ly.get_option('tmpdir')
     lib.mkdirs(tmpdir)
@@ -1282,7 +1277,7 @@ function ly.file(input_file, options)
     --[[ Here, we only take in account global option includepaths,
     as it really doesn't mean anything as a local option. --]]
     local file = locate(input_file, Score.includepaths, '.ly')
-    options = optlib.set_local_options(OPTIONS, options)
+    options = optlib.check_local_options('ly', options)
     if not file then err("File %s doesn't exist.", input_file) end
     local i = io.open(file, 'r')
     ly.score = Score:new(i:read('*a'), options, file)
@@ -1294,7 +1289,7 @@ function ly.file_musicxml(input_file, options)
     --[[ Here, we only take in account global option includepaths,
     as it really doesn't mean anything as a local option. --]]
     local file = locate(input_file, Score.includepaths, '.xml')
-    options = optlib.set_local_options(OPTIONS, options)
+    options = optlib.check_local_options('ly', options)
     if not file then err("File %s doesn't exist.", input_file) end
     local xmlopts = ''
     for _, opt in pairs(MXML_OPTIONS) do
@@ -1323,7 +1318,7 @@ end
 
 
 function ly.fragment(ly_code, options)
-    options = optlib.set_local_options(OPTIONS, options)
+    options = optlib.check_local_options('ly', options)
     if type(ly_code) == 'string' then
         ly_code = ly_code:gsub('\\par ', '\n'):gsub('\\([^%s]*) %-([^%s])', '\\%1-%2')
     else ly_code = table.concat(ly_code, '\n')
@@ -1351,7 +1346,7 @@ end
 
 
 function ly.is_neg(k, _)
-    return optlib.is_neg(OPTIONS, k)
+    return optlib.is_neg('ly', k)
 end
 
 
@@ -1381,7 +1376,7 @@ end
 end
 
 function ly.set_property(k, v)
-    k, v = optlib.sanitize_option(OPTIONS, k, v)
+    k, v = optlib.sanitize_option('ly', k, v)
     if k then Score[k] = v end
 end
 

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -1282,7 +1282,7 @@ function ly.file(input_file, options)
     --[[ Here, we only take in account global option includepaths,
     as it really doesn't mean anything as a local option. --]]
     local file = locate(input_file, Score.includepaths, '.ly')
-    options = ly.set_local_options(options)
+    options = optlib.set_local_options(OPTIONS, options)
     if not file then err("File %s doesn't exist.", input_file) end
     local i = io.open(file, 'r')
     ly.score = Score:new(i:read('*a'), options, file)
@@ -1294,7 +1294,7 @@ function ly.file_musicxml(input_file, options)
     --[[ Here, we only take in account global option includepaths,
     as it really doesn't mean anything as a local option. --]]
     local file = locate(input_file, Score.includepaths, '.xml')
-    options = ly.set_local_options(options)
+    options = optlib.set_local_options(OPTIONS, options)
     if not file then err("File %s doesn't exist.", input_file) end
     local xmlopts = ''
     for _, opt in pairs(MXML_OPTIONS) do
@@ -1323,7 +1323,7 @@ end
 
 
 function ly.fragment(ly_code, options)
-    options = ly.set_local_options(options)
+    options = optlib.set_local_options(OPTIONS, options)
     if type(ly_code) == 'string' then
         ly_code = ly_code:gsub('\\par ', '\n'):gsub('\\([^%s]*) %-([^%s])', '\\%1-%2')
     else ly_code = table.concat(ly_code, '\n')
@@ -1378,27 +1378,6 @@ end
   end
   if ly.score.sffamily == '' then ly.score.sffamily = ly.get_font_family(sf) end
   if ly.score.ttfamily == '' then ly.score.ttfamily = ly.get_font_family(tt) end
-end
-
-function ly.set_local_options(opts)
-    local options = {}
-    local next_opt = opts:gmatch('([^,]+)')  -- iterator over options
-    for opt in next_opt do
-        local k, v = opt:match('([^=]+)=?(.*)')
-        if k then
-            if v and v:sub(1, 1) == '{' then  -- handle keys with {multiple, values}
-                while v:sub(-1) ~= '}' do v = v..','..next_opt() end
-                v = v:sub(2, -2)  -- remove { }
-            end
-            k, v = optlib.sanitize_option(OPTIONS, k:gsub('^%s', ''), v:gsub('^%s', ''))
-            if k then
-                if options[k] then err('Option %s is set two times for the same score.', k)
-                else options[k] = v
-                end
-            end
-        end
-    end
-    return options
 end
 
 function ly.set_property(k, v)

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -44,7 +44,9 @@
 \catcode`-=11
 \directlua{
   ly = require(kpse.find_file("lyluatex.lua") or "lyluatex.lua")
-  ly.declare_package_options({
+  opt = require(
+      kpse.find_file("lyluatex-options.lua") or "lyluatex-options.lua")
+  opt.declare_package_options('ly', {
     ['addversion'] = {'false', 'true', ''},
     ['autoindent'] = {'true', 'false', ''},
     ['cleantmp'] = {'false', 'true', ''},

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -128,8 +128,8 @@
     ['verbose'] = {'false', 'true', ''},
     ['xml2ly'] = {'musicxml2ly'},
   })
-  ly.attach_Score_table()
 }
+\directlua{ly.attach_Score_table()}
 \directlua{ly.make_list_file()}
 \directlua{
   if opt.get_option('ly', 'cleantmp') then

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -46,40 +46,40 @@
   ly = require(kpse.find_file("lyluatex.lua") or "lyluatex.lua")
   opt = require(
       kpse.find_file("lyluatex-options.lua") or "lyluatex-options.lua")
-  opt.declare_package_options('ly', {
+  opt.declare_package_options('ly', 'opt', {
     ['addversion'] = {'false', 'true', ''},
     ['autoindent'] = {'true', 'false', ''},
     ['cleantmp'] = {'false', 'true', ''},
     ['currfiledir'] = {},
     ['debug'] = {'false', 'true', ''},
-    ['extra-bottom-margin'] = {'0', ly.is_dim},
-    ['extra-top-margin'] = {'0', ly.is_dim},
+    ['extra-bottom-margin'] = {'0', opt.is_dim},
+    ['extra-top-margin'] = {'0', opt.is_dim},
     ['fix_badly_cropped_staffgroup_brackets'] = {'false', 'true', ''},
-      ['nofix_badly_cropped_staffgroup_brackets'] = {'default', ly.is_neg},
+      ['nofix_badly_cropped_staffgroup_brackets'] = {'default', opt.is_neg},
     ['force-compilation'] = {'false', 'true', ''},
     ['fragment'] = {'', 'false', 'true'},
-        ['nofragment'] = {'default', ly.is_neg},
+        ['nofragment'] = {'default', opt.is_neg},
     ['fullpagealign'] = {'crop', 'staffline'},
     ['fullpagestyle'] = {''},
-    ['gutter'] = {'.4in', ly.is_dim},
-        ['exampleindent'] = {'gutter', ly.is_alias},
-        ['leftgutter'] = {'', ly.is_dim}, ['rightgutter'] = {'', ly.is_dim},
-    ['hpadding'] = {'0.75ex', ly.is_dim},
+    ['gutter'] = {'.4in', opt.is_dim},
+        ['exampleindent'] = {'gutter', opt.is_alias},
+        ['leftgutter'] = {'', opt.is_dim}, ['rightgutter'] = {'', opt.is_dim},
+    ['hpadding'] = {'0.75ex', opt.is_dim},
     ['include_after_body'] = {'false'},
     ['include_before_body'] = {'false'},
     ['include_footer'] = {'false'},
     ['include_header'] = {'false'},
     ['includepaths'] = {'./'},
-    ['indent'] = {'', ly.is_dim},
-        ['noindent'] = {'default', ly.is_neg},
+    ['indent'] = {'', opt.is_dim},
+        ['noindent'] = {'default', opt.is_neg},
     ['insert'] = {'', 'systems', 'fullpage', 'inline', 'bare-inline'},
     ['intertext'] = {''},
     ['label'] = {'false'}, ['labelprefix'] = {'ly_'},
-    ['line-width'] = {[[\linewidth]], ly.is_dim},
+    ['line-width'] = {[[\linewidth]], opt.is_dim},
     ['ly-version'] = {'2.18.2'},
-    ['max-protrusion'] = {[[\maxdimen]], ly.is_dim},
-        ['max-left-protrusion'] = {'', ly.is_dim},
-        ['max-right-protrusion'] = {'', ly.is_dim},
+    ['max-protrusion'] = {[[\maxdimen]], opt.is_dim},
+        ['max-left-protrusion'] = {'', opt.is_dim},
+        ['max-right-protrusion'] = {'', opt.is_dim},
     ['noclef'] = {'false', 'true', ''},
     ['nostaff'] = {'false', 'true', ''},
     ['nostaffsymbol'] = {'false', 'true', ''},
@@ -87,8 +87,8 @@
     ['notiming'] = {'false', 'true', ''},
     ['notimesig'] = {'false', 'true', ''},
     ['optimize-pdf'] = {'false', 'true', ''},
-    ['paperwidth'] = {[[\paperwidth]], ly.is_dim},
-    ['paperheight'] = {[[\paperheight]], ly.is_dim},
+    ['paperwidth'] = {[[\paperwidth]], opt.is_dim},
+    ['paperheight'] = {[[\paperheight]], opt.is_dim},
     ['papersize'] = {'false'},
     ['pass-fonts'] = {'false', 'true', ''},
         ['current-font'] = {}, ['current-font-as-main'] = {'false', 'true', ''},
@@ -100,22 +100,22 @@
         ['do-not-print'] = {''},
     ['printfilename'] = {'false', 'true', ''},
     ['program'] = {'lilypond'},
-    ['protrusion'] = {'', ly.is_dim},
-        ['noprotrusion'] = {'default', ly.is_neg},
+    ['protrusion'] = {'', opt.is_dim},
+        ['noprotrusion'] = {'default', opt.is_neg},
     ['raw-pdf'] = {'false', 'true', ''},
     ['quote'] = {'false', 'true', ''},
     ['ragged-right'] = {'default', 'true', 'false', ''},
-        ['noragged-right'] = {'default', ly.is_neg},
-    ['relative'] = {'false', ly.is_num},
-        ['norelative'] = {'default', ly.is_neg},
+        ['noragged-right'] = {'default', opt.is_neg},
+    ['relative'] = {'false', opt.is_num},
+        ['norelative'] = {'default', opt.is_neg},
     ['showfailed'] = {'false', 'true' ,''},
-    ['staffsize'] = {'0', ly.is_dim},
-        ['inline-staffsize'] = {'0', ly.is_dim},
-    ['system-count'] = {'0', ly.is_dim},
+    ['staffsize'] = {'0', opt.is_dim},
+        ['inline-staffsize'] = {'0', opt.is_dim},
+    ['system-count'] = {'0', opt.is_dim},
     ['tmpdir'] = {'tmp-ly'},
     ['twoside'] = {'\ly@istwosided', 'false', 'true', ''},
     ['verbatim'] = {'false', 'true', ''},
-    ['voffset'] = {'0pt', ly.is_dim},
+    ['voffset'] = {'0pt', opt.is_dim},
     ['valign'] = {'center', 'top', 'bottom'},
     % MusicXML options
     ['absolute'] = {'false', 'true', ''},
@@ -128,10 +128,11 @@
     ['verbose'] = {'false', 'true', ''},
     ['xml2ly'] = {'musicxml2ly'},
   })
+  ly.attach_Score_table()
 }
 \directlua{ly.make_list_file()}
 \directlua{
-  if ly.get_option('cleantmp') then
+  if opt.get_option('ly', 'cleantmp') then
     luatexbase.add_to_callback('stop_run', ly.clean_tmp_dir, 'lyluatex cleantmp')
     luatexbase.add_to_callback('stop_run', ly.conclusion_text, 'lyluatex conclusion')
   end
@@ -156,7 +157,7 @@
 }
 
 % Command to change options during the document
-\newcommand{\lysetoption}[2]{\directlua{ly.set_property([[#1]], [[#2]])}}
+\newcommand{\lysetoption}[2]{\directlua{opt.set_option('ly', [[#1]], [[#2]])}}
 
 % How the filename of a score will look like (if printed)
 \newcommand{\lyFilename}[1]{\noindent #1\par\bigskip}
@@ -172,7 +173,7 @@
 % *current* font for optional use.
 \newcommand{\ly@currentfonts}{%
   \begingroup%
-    \directlua{ly.set_property('current-font', ly.get_font_family(font.current()))}%
+    \directlua{opt.set_option('ly', 'current-font', ly.get_font_family(font.current()))}%
     \rmfamily \edef\rmfamilyid{\fontid\font}%
     \sffamily \edef\sffamilyid{\fontid\font}%
     \ttfamily \edef\ttfamilyid{\fontid\font}%
@@ -187,8 +188,8 @@
 \newcommand*{\ly@compilescore}[1]{%
   \ly@setunits%
   \directlua{
-    ly.set_property('currfiledir', [[\currfiledir]])
-    ly.set_property('twoside', '\ly@istwosided')
+    opt.set_option('ly', 'currfiledir', [[\currfiledir]])
+    opt.set_option('ly', 'twoside', '\ly@istwosided')
     #1
     ly.newpage_if_fullpage()
   }%

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -43,10 +43,10 @@
 % Options
 \catcode`-=11
 \directlua{
-  ly = require(kpse.find_file("lyluatex.lua") or "lyluatex.lua")
   opt = require(
-      kpse.find_file("lyluatex-options.lua") or "lyluatex-options.lua")
-  opt.declare_package_options('ly', 'opt', {
+    kpse.find_file("lyluatex-options.lua") or "lyluatex-options.lua"
+  )
+  ly_opts = opt.Opts:new('ly_opts', {
     ['addversion'] = {'false', 'true', ''},
     ['autoindent'] = {'true', 'false', ''},
     ['cleantmp'] = {'false', 'true', ''},
@@ -129,10 +129,10 @@
     ['xml2ly'] = {'musicxml2ly'},
   })
 }
-\directlua{ly.attach_Score_table()}
-\directlua{ly.make_list_file()}
 \directlua{
-  if opt.get_option('ly', 'cleantmp') then
+  ly = require(kpse.find_file("lyluatex.lua") or "lyluatex.lua")
+  ly.make_list_file()
+  if ly_opts.cleantmp then
     luatexbase.add_to_callback('stop_run', ly.clean_tmp_dir, 'lyluatex cleantmp')
     luatexbase.add_to_callback('stop_run', ly.conclusion_text, 'lyluatex conclusion')
   end
@@ -157,7 +157,7 @@
 }
 
 % Command to change options during the document
-\newcommand{\lysetoption}[2]{\directlua{opt.set_option('ly', [[#1]], [[#2]])}}
+\newcommand{\lysetoption}[2]{\directlua{ly_opts:set_option([[#1]], [[#2]])}}
 
 % How the filename of a score will look like (if printed)
 \newcommand{\lyFilename}[1]{\noindent #1\par\bigskip}
@@ -173,7 +173,7 @@
 % *current* font for optional use.
 \newcommand{\ly@currentfonts}{%
   \begingroup%
-    \directlua{opt.set_option('ly', 'current-font', ly.get_font_family(font.current()))}%
+    \directlua{ly_opts:set_option('current-font', ly.get_font_family(font.current()))}%
     \rmfamily \edef\rmfamilyid{\fontid\font}%
     \sffamily \edef\sffamilyid{\fontid\font}%
     \ttfamily \edef\ttfamilyid{\fontid\font}%
@@ -188,8 +188,8 @@
 \newcommand*{\ly@compilescore}[1]{%
   \ly@setunits%
   \directlua{
-    opt.set_option('ly', 'currfiledir', [[\currfiledir]])
-    opt.set_option('ly', 'twoside', '\ly@istwosided')
+    ly_opts:set_option('currfiledir', [[\currfiledir]])
+    ly_opts:set_option('twoside', '\ly@istwosided')
     #1
     ly.newpage_if_fullpage()
   }%


### PR DESCRIPTION
I think it is a good idea to factor out an additional module `lyluatex-options`.
With that separation third-party code (including my own, I'm talking of a public package like [lyluatexmp](https://github.com/uliska/lyluatexmp) and private packages for custom project code) can either include either the option handling infrastructure or only the generic toolkit.

Probably it would also be a good idea to move those two Lua modules `lyluatex-lib` and `lyluatex-options` to a new separate LuaLaTeX package so it could be distributed and used independently from `lyluatex` altogether. But I'm not so sure how that would have to be done and how a pure-Lua package would actually be integrated in something like TeXLive (maybe it would simply be installed and not be used with `\usepackage` at all).

What should be done in any case is writing package author's documentation on how to make use of the option handling system. I think this really was a great way to make `lyluatex` configurable, and I think this could be generally useful for creating new Lua-based packages.