### PR TITLE
optlib.merge_options

### DIFF
--- a/lyluatex-options.lua
+++ b/lyluatex-options.lua
@@ -255,7 +255,7 @@ function optlib.merge_options(base_opt, super_opt)
     super_opt. Entries in super_opt supersede (i.e. overwrite)
     colliding entries in base_opt.
 --]]
-    result = {}
+    local result = {}
     for k, v in pairs(base_opt) do result[k] = v end
     for k, v in pairs(super_opt) do result[k] = v end
     return result

--- a/lyluatex-options.lua
+++ b/lyluatex-options.lua
@@ -248,5 +248,19 @@ function optlib.is_str(_, v)
 end
 
 
+function optlib.merge_options(base_opt, super_opt)
+--[[
+    Merge two tables.
+    Create a new table as a copy of base_opt, then merge with
+    super_opt. Entries in super_opt supersede (i.e. overwrite)
+    colliding entries in base_opt.
+--]]
+    result = {}
+    for k, v in pairs(base_opt) do result[k] = v end
+    for k, v in pairs(super_opt) do result[k] = v end
+    return result
+end
+
+
 optlib.Opts = Opts
 return optlib


### PR DESCRIPTION
A helper function to create a table with current options superseded
by local options. This is not needed in lyluatex where the same result
is achieved through the Score object, but typically a client is required
to perform this merge for *any* score (or other element).

@jperon there may be a few more minor PRs coming, although I really have to get back to writing *content*. But I want to drive my [lyluatexmp](https://github.com/uliska/lyluatexmp) package to the initial point where I can replace the old solution with the new package (i.e. have one command `\lyfilemusicexample` ready to be used). In that process I find that a number of tool functions “appear“ that need to be factored out, some to my own helper modules but some also to `lyluatex`. Maybe it is a good idea to merge these modules to one common LaTeX package at some point (when `lyluatex` has been through its next proper release and my own project is submitted).