### PR TITLE
Retry lilypond command when failed

### DIFF
--- a/lyluatex-lib.lua
+++ b/lyluatex-lib.lua
@@ -135,4 +135,29 @@ function lib.splitext(str, ext)
         or (str:match('(.*)%.(%w*)$') or str)
 end
 
+
+------------------------------------
+-- Engine, version, TeX distribution
+
+local tex_engine = {}
+setmetatable(tex_engine, tex_engine)
+
+function tex_engine:__call()
+--[[
+    Defines the properties extracted from the first line of jobname.log.
+--]]
+    local f = io.open(tex.jobname..'.log')
+    if not f then return end
+    self.engine, self.engine_version, self.dist, self.dist_version, self.format, self.format_version =
+        f:read():match(
+            'This is ([^,]*), Version ([^%(]*) %(([^%)]*) ([^%)]*)%)%s+%(format=([^%)]*) ([^)]*)%)'
+        )
+    f:close()
+    return self
+end
+
+function tex_engine:__index(k) return rawget(self(), k) end
+
+
+lib.tex_engine = tex_engine
 return lib

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -1123,7 +1123,7 @@ function Score:run_lily_proc(p)
 function Score:run_lilypond()
     if self:is_compiled() then return end
     lib.mkdirs(lib.dirname(self.output))
-    if not self:run_lily_proc(io.popen(self:lilypond_cmd(self.complete_ly_code))) and not debug then
+    if not self:run_lily_proc(io.popen(self:lilypond_cmd(self.complete_ly_code))) and not self.debug then
         self.debug = true
         self.lilypond_error = not self:run_lily_proc(io.popen(self:lilypond_cmd(self.complete_ly_code)))
     end

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -811,6 +811,7 @@ function Score:lilypond_cmd()
         cmd = cmd..'-I "'..dir:gsub('^%./', lfs.currentdir()..'/')..'" '
     end
     cmd = cmd..'-o "'..self.output..'" '..input
+    if lib.tex_engine.dist == 'MiKTeX' then cmd = '"'..cmd..'"' end
     debug("Command:\n"..cmd)
     return cmd, mode
 end
@@ -1122,13 +1123,9 @@ function Score:run_lily_proc(p)
 function Score:run_lilypond()
     if self:is_compiled() then return end
     lib.mkdirs(lib.dirname(self.output))
-    if not self:run_lily_proc(io.popen(self:lilypond_cmd(self.complete_ly_code))) then  -- TeXLive - normal case
+    if not self:run_lily_proc(io.popen(self:lilypond_cmd(self.complete_ly_code))) and not debug then
         self.debug = true
-        local lilypond_cmd = self:lilypond_cmd(self.complete_ly_code)
-        local quoted_lilypond_cmd = '"'..lilypond_cmd..'"'
-        self.lilypond_error =
-            not self:run_lily_proc(io.popen(quoted_lilypond_cmd))  -- MiKTeX - normal case
-            and not self:run_lily_proc(io.popen(lilypond_cmd))  -- In case of errors
+        self.lilypond_error = not self:run_lily_proc(io.popen(self:lilypond_cmd(self.complete_ly_code)))
     end
 end
 

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -43,6 +43,7 @@
 % Options
 \catcode`-=11
 \directlua{
+  local lib = require(kpse.find_file("lyluatex-lib.lua") or "lyluatex-lib.lua")
   local _opt = require(
     kpse.find_file("lyluatex-options.lua") or "lyluatex-options.lua"
   )
@@ -129,6 +130,7 @@
     ['verbose'] = {'false', 'true', ''},
     ['xml2ly'] = {'musicxml2ly'},
   })
+  if lib.tex_engine.dist == 'MiKTeX' then ly_opts:set_option('debug', true) end
 }
 \directlua{
   ly = require(kpse.find_file("lyluatex.lua") or "lyluatex.lua")

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -43,7 +43,6 @@
 % Options
 \catcode`-=11
 \directlua{
-  local lib = require(kpse.find_file("lyluatex-lib.lua") or "lyluatex-lib.lua")
   local _opt = require(
     kpse.find_file("lyluatex-options.lua") or "lyluatex-options.lua"
   )
@@ -130,7 +129,6 @@
     ['verbose'] = {'false', 'true', ''},
     ['xml2ly'] = {'musicxml2ly'},
   })
-  if lib.tex_engine.dist == 'MiKTeX' then ly_opts:set_option('debug', true) end
 }
 \directlua{
   ly = require(kpse.find_file("lyluatex.lua") or "lyluatex.lua")


### PR DESCRIPTION
Fix #204: MiKTeX behavior isn't the same as TexLive's with io.popen. I
don't know why, but on MiKTeX, we have to add a level of quotes, and
it doesn't seem to be able to write code to stdin.

Incidentally, when LilyPond fails on a score, compilation is re-tried
with debug=true.