### PR TITLE
Remove RequirePackage-s

### DIFF
--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -8,8 +8,6 @@
 \ProvidesPackage{lyluatex}[2019/05/27 v1.0f]  %%LYLUATEX_DATE LYLUATEX_VERSION
 
 % Dependencies
-\RequirePackage{luatexbase}
-\RequirePackage{luaotfload}
 \RequirePackage{xkeyval}
 \RequirePackage{graphicx}
 \RequirePackage{minibox}


### PR DESCRIPTION
These are now required in lyluatextools, so the RequirePackage is
not needed anymore in lyluatex.sty