### PR TITLE
Move xkeyval dependency to lyluatextools

### DIFF
--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -8,7 +8,6 @@
 \ProvidesPackage{lyluatex}[2019/05/27 v1.0f]  %%LYLUATEX_DATE LYLUATEX_VERSION
 
 % Dependencies
-\RequirePackage{xkeyval}
 \RequirePackage{graphicx}
 \RequirePackage{minibox}
 \RequirePackage{environ}

--- a/lyluatextools.sty
+++ b/lyluatextools.sty
@@ -10,6 +10,7 @@
 % Dependencies
 \RequirePackage{luatexbase}
 \RequirePackage{luaotfload}
+\RequirePackage{xkeyval}
 
 % Helper macro
 \def\ly@load@module#1#2{


### PR DESCRIPTION
The xkeyval functionality is already needed in lyluatextools,
i.e. when this is loaded independently or before lyluatex.

(My use case is that I load lyluatextools, then set up my option handling
and configuration and then already use these options when loading
lyluatex and lyluatexmp).