### PR TITLE
\lyuseoption as wrapper to Opts:use_option

### DIFF
--- a/lyluatex-options.lua
+++ b/lyluatex-options.lua
@@ -158,6 +158,12 @@ function Opts:use_option(key)
     end
 end
 
+-- Wrapper macro to simplify the use of Opts:use_option
+local use_option = [[
+\newcommand*{\lyuseoption}[2]{%
+\directlua{#1:use_option('#2')}}]]
+tex.print(use_option:explode('\n'))
+
 function Opts:validate_option(key, options_obj)
 --[[
     Validate an (already sanitized) option against its expected values.
@@ -274,7 +280,6 @@ function optlib.merge_options(base_opt, super_opt)
     for k, v in pairs(super_opt) do result[k] = v end
     return result
 end
-
 
 optlib.Opts = Opts
 return optlib


### PR DESCRIPTION
I've come to the conclusion that it's a courtesy to the user to
reduce the need to use \directlua wherever possible ...

Use case: In a document preamble it is with this patch possible to write

```tex
\RequirePackage[%
    left=\lyuseoption{my_opts}{layout_left},%
    right=\lyuseoption{my_opts}{layout_right},%
]{geometry}

rather than having to call `my_opts:use_option(layout_left)` in a `\directlua` clause
```