### PR TITLE
Add tall-page-formats option

### DIFF
--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -808,7 +808,7 @@ function Score:lilypond_cmd()
     end
     local cmd = '"'..self.program..'" '
         .. (self.insert == "fullpage" and "" or "-E ")
-        .. "-dno-point-and-click -djob-count=2 -dno-delete-intermediate-files "
+        .. "-dno-point-and-click -djob-count=2 -dno-delete-intermediate-files -dtall-page-formats=pdf "
     if self['optimize-pdf'] and self:lilypond_has_TeXGS() then cmd = cmd.."-O TeX-GS -dgs-never-embed-fonts " end
     if self.input_file then
         cmd = cmd..'-I "'..lib.dirname(self.input_file):gsub('^%./', lfs.currentdir()..'/')..'" '

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -808,7 +808,8 @@ function Score:lilypond_cmd()
     end
     local cmd = '"'..self.program..'" '
         .. (self.insert == "fullpage" and "" or "-E ")
-        .. "-dno-point-and-click -djob-count=2 -dno-delete-intermediate-files -dtall-page-formats=pdf "
+        .. "-dno-point-and-click -djob-count=2 -dno-delete-intermediate-files "
+    if self:lilypond_version() >= ly.v{2, 24} then cmd = cmd.."-dtall-page-formats=pdf " end
     if self['optimize-pdf'] and self:lilypond_has_TeXGS() then cmd = cmd.."-O TeX-GS -dgs-never-embed-fonts " end
     if self.input_file then
         cmd = cmd..'-I "'..lib.dirname(self.input_file):gsub('^%./', lfs.currentdir()..'/')..'" '


### PR DESCRIPTION
LilyPond 2.24 introduced a change to the way the eps and pdf files are produced.  In particular, when using the lilypond-book preamble (a version of which is used in this package) to produce separate files for each system, the pdf file that included all the music contained one page per system while the eps file that include all music was a single page.  This meant that if the first line of the score was significantly different from the subsequent lines (e.g., a header with material flushed right instead of a music stave), then scores would get placed in unexpected positions.  This was the result of the eps bounding box and the pdf bounding box being based on different parts of the music (the whole score in the former case, and only the first line in the latter).

By adding the `-dtall-page-formats=pdf` option to the LilyPond compilation, the pdf containing all the music will put all the music on a single page, thus matching the eps file and allowing the bounding box calculations to be use more comparable values.

Fixes #307 