### PR TITLE
Use `protrusion_left` instead of `protrusion`

### DIFF
--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -239,7 +239,7 @@ local function set_lyscore(score)
     ly.score = score
     ly.score.nsystems = ly.score:count_systems()
     if score.insert ~= 'fullpage' then  -- systems and inline
-        local hoffset = ly.score.protrusion or 0
+        local hoffset = ly.score.protrusion_left or 0
         if hoffset == '' then hoffset = 0 end
         ly.score.hoffset = hoffset..'pt'
         for s = 1, ly.score.nsystems do


### PR DESCRIPTION
Use `protrusion_left` instead of `protrusion` for horizontal offset in scores.

<img width="390" height="619" alt="image" src="https://github.com/user-attachments/assets/f855c8ee-e580-4439-b4ba-12a97284a281" />


Fix #283