### PR TITLE
clip-regions feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,5 @@ sympy-plots-for-*.tex/
 # lyluatex temp directories
 *tmp-ly/
 /lyluatex.tex
+lyluatex.code-workspace
+lyluatex.lua.old

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 test:
 	TEXINPUTS=luaoptions: lualatex -interaction=nonstopmode -shell-escape test.tex
+	TEXINPUTS=luaoptions: lualatex -interaction=nonstopmode -shell-escape test-clipregions.tex
 
 manual:
 	@lua -e "if tonumber(io.popen('pandoc -v'):read():gsub('pandoc (.*)', '%1'):sub(1,1)) < 2 then print('Pandoc >= 2 required') ; os.exit(1) ; end"

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -90,7 +90,7 @@ local LY_HEAD = [[
 ]]
 
 
---- fsarud: Clip-regions engraver to force a snippet to start on a new system. It can manage multiple fragments, but in lyluatex the feature is limited to a single fragment in the form: "clip-regions=aa-bb", where aa and bb are measure numbers.
+--- Clip-regions engraver to force a snippet to start on a new system. It can manage multiple fragments, but in lyluatex the feature is limited to a single fragment in the form: "clip-regions=aa-bb", where aa and bb are measure numbers.
 local CLIP_BREAK_ENGRAVER = [[
 #(define (Clip_break_engraver context)
    (let ((break-measures '()))
@@ -112,7 +112,6 @@ local CLIP_BREAK_ENGRAVER = [[
                          (cons* start fine break-measures))))
                regions)))))))
 ]]
--- fin fsarud
 
 
 --[[ ========================== Helper functions ========================== --]]
@@ -263,42 +262,36 @@ end
 local function set_lyscore(score)
     ly.score = score
     
-    -- fsarud: if clip-regions is set:
     if score['clip-regions'] and score['clip-regions'] ~= '' then
-        -- Override indent 
-        local hoffset = score.protrusion or 0
-        if hoffset == '' then hoffset = 0 end
-        score.hoffset = hoffset..'pt'
-        
+        score.protrusion_left = 0
+        score.indent_offset = 0
+        score.leftgutter = 0
+
         local base_name = score.output:match("[^/]*$")
         local clips = {}
-        
-        -- collect PDFs belonging to this hash
+
         pcall(function()
             for file in lfs.dir(score.tmpdir) do
-                -- that starts with the hash and contains "-clip"
                 if file:find("^" .. base_name) and file:find("%-clip") and file:sub(-4) == ".pdf" then
                     local clip_name = file:gsub("%.pdf$", "")
                     table.insert(clips, clip_name)
                 end
             end
         end)
-        
-        -- Sort if there are several systems
+
         table.sort(clips, function(a, b)
             local num_a = a:match("%-clip%-(%d+)$")
             local num_b = b:match("%-clip%-(%d+)$")
-            
+
             local n_a = num_a and tonumber(num_a)
             local n_b = num_b and tonumber(num_b)
-            
+
             if n_a and n_b then return n_a > n_b end
             if n_a and not n_b then return true end
             if not n_a and n_b then return false end
             return a < b
         end)
-        
-        -- Inject formatted paths as expected by LaTeX backend
+
         for _, clip_file in ipairs(clips) do
             table.insert(score, score.tmpdir .. '/' .. clip_file)
         end
@@ -307,18 +300,8 @@ local function set_lyscore(score)
         score.range = {}
         for i = 1, score.nsystems do table.insert(score.range, i) end
 
-        -- Remove all intermediate .eps files associated with this hash
-        pcall(function()
-            for file in lfs.dir(score.tmpdir) do
-                if file:find(base_name, 1, true) and file:sub(-4) == ".eps" then
-                    os.remove(score.tmpdir .. '/' .. file)
-                end
-            end
-        end)
-        
         return
     end
-    -- end fsarud
 
     ly.score.nsystems = ly.score:count_systems()
     if score.insert ~= 'fullpage' then
@@ -441,22 +424,16 @@ function latex_includesystems(filename, range, protrusion, gutter, staffsize, in
     local texoutput = '\\ifx\\preLilyPondExample\\undefined\\else\\preLilyPondExample\\fi\n'
     texoutput = texoutput..'\\par\n'
     
-    -- fsarud:  if clip-regions is set
-    local es_clip = ly.score and ly.score['clip-regions'] and ly.score['clip-regions'] ~= ''
+    local is_clip = ly.score and ly.score['clip-regions'] and ly.score['clip-regions'] ~= ''
 
     for index, system in pairs(range) do
         local path_graphic
         local h_space = h_offset + gutter
         
-        if es_clip then
-            -- If it is a clip, we take the exact path ordered we stored in table
+        if is_clip then
             path_graphic = ly.score[index]
-            h_offset = 0 -- Override identation. This can be enhanced
-            gutter = 0
-            -- Just in case...
             if not path_graphic then break end
-        else
-            -- If it is a normal score, we use the default lyluatex behavior
+        else -- Default lyluatex behavior
             if not lfs.isfile(filename..'-'..system..'.eps') then break end
             path_graphic = filename..'-'..system
         end
@@ -468,8 +445,6 @@ function latex_includesystems(filename, range, protrusion, gutter, staffsize, in
             h_offset + gutter,path_graphic
             )
         if index < #range then
-    --end fsarud 
-
             texoutput = texoutput..
                 string.format([[
 \ifx\betweenLilyPondSystem\undefined\par\vspace{%fpt plus %fpt minus %fpt}%%
@@ -869,15 +844,13 @@ function Score:count_systems(force)
         count = 0
         local base_name = self.output:match("[^/]*$")
         
-        -- fsarud: if clip-systems is set: count PDFs generated (EPS are no longer there)
         if self['clip-regions'] and self['clip-regions'] ~= '' then
             for f in lfs.dir(self.tmpdir) do
                 if f:find(base_name, 1, true) and f:find("-clip", 1, true) and f:sub(-4) == ".pdf" then
                     count = count + 1
                 end
             end
-        else
-            -- If not, original logic with EPS files
+        else -- original logic
             local systems = base_name.."%-%d+%.eps"
             for f in lfs.dir(self.tmpdir) do
                 if f:match(systems) then
@@ -885,7 +858,6 @@ function Score:count_systems(force)
                 end
             end
         end
-        -- end fsarud
         self.system_count = count
     end
     return count
@@ -893,11 +865,23 @@ end
 
 function Score:delete_intermediate_files()
     for _, filename in pairs(self.output_names) do
-        if self.insert == 'fullpage' then os.remove(filename..'.ps')
+        if self.insert == 'fullpage' then 
+            os.remove(filename..'.ps')
         else
             os.remove(filename..'-systems.tex')
             os.remove(filename..'-systems.texi')
-            os.remove(filename..'.eps')
+
+            -- If clip-regions
+            if self['clip-regions'] and self['clip-regions'] ~= '' then
+                local base_name = filename:match("[^/]*$")
+                for file in lfs.dir(self.tmpdir) do
+                    if file:find(base_name, 1, true) and file:sub(-4) == ".eps" then
+                        os.remove(self.tmpdir..'/'..file)
+                    end
+                end
+            else
+                os.remove(filename..'.eps')
+            end
         end
     end
 end
@@ -952,17 +936,14 @@ function Score:header()
         end
     end
 
-    -- fsarud: if clip-regions is set, inyect engraver at start and adapt preamble
     if self['clip-regions'] and self['clip-regions'] ~= '' then
         header = CLIP_BREAK_ENGRAVER .. "\n" .. header
-    -- Look for the original include and paste below the modifier 
         header = header:gsub(
             [[%\include "lilypond%-book%-preamble.ly"]], 
             [[\include "lilypond-book-preamble.ly"
-                #(define default-toplevel-book-handler print-book-with-defaults)]] --This is to allow dclip-systems
+                #(define default-toplevel-book-handler print-book-with-defaults)]] --This is to allow dclip-systems to work
         )
     end
-    --- end fsarud
 
     return header
 end
@@ -994,11 +975,10 @@ function Score:lilypond_cmd()
         .. (self.insert == "fullpage" and "" or "-E ")
         .. "-dno-point-and-click -djob-count=2 -dno-delete-intermediate-files "
 
-    -- fsarud: Si hay clip-regions, activamos dclip-systems obligatoriamente
     if self['clip-regions'] and self['clip-regions'] ~= '' then
         cmd = cmd .. "-dclip-systems "
+        cmd = cmd:gsub("%-E%s*", "") --remove -E option if present. 
     end
-    -- fin fsarud
 
     if self:lilypond_version() >= ly.v{2, 24} then cmd = cmd.."-dtall-page-formats=pdf " end
     if self['optimize-pdf'] and self:lilypond_has_TeXGS() then
@@ -1223,25 +1203,22 @@ function Score:ly_staffprops()
     if self.notimesig then timesig = [[\context { \Staff \remove "Time_signature_engraver" }]] end
     if self.nostaffsymbol then staff = [[\context { \Staff \remove "Staff_symbol_engraver" }]] end
 
-    -- fsarud: clip-regions 
     local clip_code = '%% no clip-regions set'
     if self['clip-regions'] and self['clip-regions'] ~= '' then
-        -- eliminamos espacios por las dudas y buscamos los números separados por guión
-        local limpio = self['clip-regions']:gsub('%s+', '')
-        local start, fin = limpio:match("(%d+)%-(%d+)")
-        if start and fin then
+        local clean = self['clip-regions']:gsub('%s+', '')
+        local start, fine = clean:match("(%d+)%-(%d+)")
+        if start and fine then
             clip_code = string.format([[
     clip-regions = #(list (cons (make-rhythmic-location %s 0 1) (make-rhythmic-location %s 0 1)))
     \context {
         \Score
         \consists \Clip_break_engraver
-    }]], start, tonumber(fin) + 1)
+    }]], start, tonumber(fine) + 1)
         else
             clip_code = '%% Wrong format for clip-regions. Should be start-end, e.g. 52-74 for measures 52 to 74. Ignoring.'
         end
     end
     return string.format('%s\n%s\n%s\n%s\n%s', clef, timing, timesig, staff, clip_code)
-    -- fin fsarud
 end
 
 function Score:ly_twoside() if self.twoside then return 't' else return 'f' end end

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -90,6 +90,31 @@ local LY_HEAD = [[
 ]]
 
 
+--- fsarud: clip-regions engraver para que el fragmento comience en un sistema nuevo. Está preparado para recibir más de un fragmento, pero en lyluatex limitamos la feature a un solo fragmento de la forma clip-regions=aa-bb
+local CLIP_BREAK_ENGRAVER = [[
+#(define (Clip_break_engraver context)
+   (let ((medidas-quiebre '()))
+     (make-engraver
+      (acknowledgers
+        ((non-musical-paper-column-interface engraver grob source-engraver)
+         (if (memv (ly:context-property context 'currentBarNumber) medidas-quiebre)
+             (ly:grob-set-property! grob 'line-break-permission 'force))))
+      ((initialize engraver)
+       (let* ((paper (ly:context-output-def context))
+              (regiones (ly:output-def-lookup paper 'clip-regions)))
+         (if (list? regiones)
+             (for-each
+               (lambda (reg)
+                 ;; reg es (start-loc . end-loc), cada loc es (compás . momento)
+                 (let ((inicio (car (car reg)))
+                       (fin    (car (cdr reg))))
+                   (set! medidas-quiebre
+                         (cons* inicio fin medidas-quiebre))))
+               regiones)))))))
+]]
+-- fin fsarud
+
+
 --[[ ========================== Helper functions ========================== --]]
 -- dirty fix as info doesn't work as expected
 local oldinfo = info
@@ -237,8 +262,66 @@ end
 
 local function set_lyscore(score)
     ly.score = score
+    
+    -- fsarud: código si hay clip-regions
+    if score['clip-regions'] and score['clip-regions'] ~= '' then
+        -- anulamos cualquier medida de indentación.
+        local hoffset = score.protrusion or 0
+        if hoffset == '' then hoffset = 0 end
+        score.hoffset = hoffset..'pt'
+        
+        local base_name = score.output:match("[^/]*$")
+        local clips = {}
+        
+        -- juntamos únicamente los archivos que pertenecen a este hash y son clips
+        pcall(function()
+            for file in lfs.dir(score.tmpdir) do
+                -- que empiece con el hash y contenga "-clip"
+                if file:find("^" .. base_name) and file:find("%-clip") and file:sub(-4) == ".pdf" then
+                    local clip_name = file:gsub("%.pdf$", "")
+                    table.insert(clips, clip_name)
+                end
+            end
+        end)
+        
+        -- ordenamos si son varios sistemas.
+        table.sort(clips, function(a, b)
+            local num_a = a:match("%-clip%-(%d+)$")
+            local num_b = b:match("%-clip%-(%d+)$")
+            
+            local n_a = num_a and tonumber(num_a)
+            local n_b = num_b and tonumber(num_b)
+            
+            if n_a and n_b then return n_a > n_b end
+            if n_a and not n_b then return true end
+            if not n_a and n_b then return false end
+            return a < b
+        end)
+        
+        -- inyectamos las rutas formateadas de forma idéntica a como las espera el backend de LaTeX
+        for _, clip_file in ipairs(clips) do
+            table.insert(score, score.tmpdir .. '/' .. clip_file)
+        end
+
+        score.nsystems = #clips
+        score.range = {}
+        for i = 1, score.nsystems do table.insert(score.range, i) end
+
+        -- borro todo archivo eps de este hash. solamente me quedo con los pdf
+        pcall(function()
+            for file in lfs.dir(score.tmpdir) do
+                if file:find(base_name, 1, true) and file:sub(-4) == ".eps" then
+                    os.remove(score.tmpdir .. '/' .. file)
+                end
+            end
+        end)
+        
+        return
+    end
+    -- fin fsarud
+
     ly.score.nsystems = ly.score:count_systems()
-    if score.insert ~= 'fullpage' then  -- systems and inline
+    if score.insert ~= 'fullpage' then
         local hoffset = ly.score.protrusion or 0
         if hoffset == '' then hoffset = 0 end
         ly.score.hoffset = hoffset..'pt'
@@ -357,15 +440,36 @@ function latex_includesystems(filename, range, protrusion, gutter, staffsize, in
     local h_offset = protrusion + indent_offset
     local texoutput = '\\ifx\\preLilyPondExample\\undefined\\else\\preLilyPondExample\\fi\n'
     texoutput = texoutput..'\\par\n'
+    
+    -- fsarud: clip-regions
+    local es_clip = ly.score and ly.score['clip-regions'] and ly.score['clip-regions'] ~= ''
+
     for index, system in pairs(range) do
-        if not lfs.isfile(filename..'-'..system..'.eps') then break end
+        local ruta_grafico
+        local h_space = h_offset + gutter
+        
+        if es_clip then
+            -- si es un clip, tomamos la ruta exacta y ordenada que guardamos en la tabla
+            ruta_grafico = ly.score[index]
+            h_offset = 0 -- anulo indentación. esto se puede mejorar
+            gutter = 0
+            -- salvaguarda: si por alguna razon no esta poblado, rompemos el bucle
+            if not ruta_grafico then break end
+        else
+            -- si es una partitura normal, usamos lo que hace originalmente lyluatex
+            if not lfs.isfile(filename..'-'..system..'.eps') then break end
+            ruta_grafico = filename..'-'..system
+        end
+
         texoutput = texoutput..
             string.format([[
 \noindent\hspace*{%fpt}\includegraphics{%s}%%
 ]],
-                h_offset + gutter, filename..'-'..system
+            h_offset + gutter,ruta_grafico
             )
         if index < #range then
+    --fin fsarud 
+
             texoutput = texoutput..
                 string.format([[
 \ifx\betweenLilyPondSystem\undefined\par\vspace{%fpt plus %fpt minus %fpt}%%
@@ -763,12 +867,25 @@ function Score:count_systems(force)
     local count = self.system_count
     if force or not count then
         count = 0
-        local systems = self.output:match("[^/]*$").."%-%d+%.eps"
-        for f in lfs.dir(self.tmpdir) do
-            if f:match(systems) then
-                count = count + 1
+        local base_name = self.output:match("[^/]*$")
+        
+        -- fsarud: clip-systems. si es un clip, contamos los PDFs de clips generados (ya que los EPS se purgan)
+        if self['clip-regions'] and self['clip-regions'] ~= '' then
+            for f in lfs.dir(self.tmpdir) do
+                if f:find(base_name, 1, true) and f:find("-clip", 1, true) and f:sub(-4) == ".pdf" then
+                    count = count + 1
+                end
+            end
+        else
+            -- si no, va la lógica original para partituras estándar (busca .eps)
+            local systems = base_name.."%-%d+%.eps"
+            for f in lfs.dir(self.tmpdir) do
+                if f:match(systems) then
+                    count = count + 1
+                end
             end
         end
+        -- fin fsarud
         self.system_count = count
     end
     return count
@@ -834,6 +951,19 @@ function Score:header()
             warn([[Ignoring 'write-headers' for non-file score.]])
         end
     end
+
+    -- fsarud: clip-regions, inyecto el engraver al inicio y limpio el preamble
+    if self['clip-regions'] and self['clip-regions'] ~= '' then
+        header = CLIP_BREAK_ENGRAVER .. "\n" .. header
+    -- buscamos el include original y le pegamos abajo la redefinición del handler nativo
+        header = header:gsub(
+            [[%\include "lilypond%-book%-preamble.ly"]], 
+            [[\include "lilypond-book-preamble.ly"
+                #(define default-toplevel-book-handler print-book-with-defaults)]] --esto es para que permita los clips con dclip-systems
+        )
+    end
+    --- fin fsarud
+
     return header
 end
 
@@ -863,6 +993,13 @@ function Score:lilypond_cmd()
     local cmd = shell_quote(self.program) .. ' '
         .. (self.insert == "fullpage" and "" or "-E ")
         .. "-dno-point-and-click -djob-count=2 -dno-delete-intermediate-files "
+
+    -- fsarud: Si hay clip-regions, activamos dclip-systems obligatoriamente
+    if self['clip-regions'] and self['clip-regions'] ~= '' then
+        cmd = cmd .. "-dclip-systems "
+    end
+    -- fin fsarud
+
     if self:lilypond_version() >= ly.v{2, 24} then cmd = cmd.."-dtall-page-formats=pdf " end
     if self['optimize-pdf'] and self:lilypond_has_TeXGS() then
         cmd = cmd.."-O TeX-GS -dgs-never-embed-fonts "
@@ -1085,7 +1222,26 @@ function Score:ly_staffprops()
     if self.notiming then timing = [[\context { \Score timing = ##f }]] end
     if self.notimesig then timesig = [[\context { \Staff \remove "Time_signature_engraver" }]] end
     if self.nostaffsymbol then staff = [[\context { \Staff \remove "Staff_symbol_engraver" }]] end
-    return string.format('%s\n%s\n%s\n%s', clef, timing, timesig, staff)
+
+    -- fsarud: clip-regions 
+    local clip_code = '%% no clip-regions set'
+    if self['clip-regions'] and self['clip-regions'] ~= '' then
+        -- eliminamos espacios por las dudas y buscamos los números separados por guión
+        local limpio = self['clip-regions']:gsub('%s+', '')
+        local inicio, fin = limpio:match("(%d+)%-(%d+)")
+        if inicio and fin then
+            clip_code = string.format([[
+    clip-regions = #(list (cons (make-rhythmic-location %s 0 1) (make-rhythmic-location %s 0 1)))
+    \context {
+        \Score
+        \consists \Clip_break_engraver
+    }]], inicio, tonumber(fin) + 1)
+        else
+            clip_code = '%% Wrong format for clip-regions. Should be start-end, e.g. 52-74 for measures 52 to 74. Ignoring.'
+        end
+    end
+    return string.format('%s\n%s\n%s\n%s\n%s', clef, timing, timesig, staff, clip_code)
+    -- fin fsarud
 end
 
 function Score:ly_twoside() if self.twoside then return 't' else return 'f' end end

--- a/lyluatex.lua
+++ b/lyluatex.lua
@@ -90,27 +90,27 @@ local LY_HEAD = [[
 ]]
 
 
---- fsarud: clip-regions engraver para que el fragmento comience en un sistema nuevo. Está preparado para recibir más de un fragmento, pero en lyluatex limitamos la feature a un solo fragmento de la forma clip-regions=aa-bb
+--- fsarud: Clip-regions engraver to force a snippet to start on a new system. It can manage multiple fragments, but in lyluatex the feature is limited to a single fragment in the form: "clip-regions=aa-bb", where aa and bb are measure numbers.
 local CLIP_BREAK_ENGRAVER = [[
 #(define (Clip_break_engraver context)
-   (let ((medidas-quiebre '()))
+   (let ((break-measures '()))
      (make-engraver
       (acknowledgers
         ((non-musical-paper-column-interface engraver grob source-engraver)
-         (if (memv (ly:context-property context 'currentBarNumber) medidas-quiebre)
+         (if (memv (ly:context-property context 'currentBarNumber) break-measures)
              (ly:grob-set-property! grob 'line-break-permission 'force))))
       ((initialize engraver)
        (let* ((paper (ly:context-output-def context))
-              (regiones (ly:output-def-lookup paper 'clip-regions)))
-         (if (list? regiones)
+              (regions (ly:output-def-lookup paper 'clip-regions)))
+         (if (list? regions)
              (for-each
                (lambda (reg)
-                 ;; reg es (start-loc . end-loc), cada loc es (compás . momento)
-                 (let ((inicio (car (car reg)))
-                       (fin    (car (cdr reg))))
-                   (set! medidas-quiebre
-                         (cons* inicio fin medidas-quiebre))))
-               regiones)))))))
+                 ;; reg is (start-loc . end-loc), loc is (measure . moment)
+                 (let ((start (car (car reg)))
+                       (fine    (car (cdr reg))))
+                   (set! break-measures
+                         (cons* start fine break-measures))))
+               regions)))))))
 ]]
 -- fin fsarud
 
@@ -263,9 +263,9 @@ end
 local function set_lyscore(score)
     ly.score = score
     
-    -- fsarud: código si hay clip-regions
+    -- fsarud: if clip-regions is set:
     if score['clip-regions'] and score['clip-regions'] ~= '' then
-        -- anulamos cualquier medida de indentación.
+        -- Override indent 
         local hoffset = score.protrusion or 0
         if hoffset == '' then hoffset = 0 end
         score.hoffset = hoffset..'pt'
@@ -273,10 +273,10 @@ local function set_lyscore(score)
         local base_name = score.output:match("[^/]*$")
         local clips = {}
         
-        -- juntamos únicamente los archivos que pertenecen a este hash y son clips
+        -- collect PDFs belonging to this hash
         pcall(function()
             for file in lfs.dir(score.tmpdir) do
-                -- que empiece con el hash y contenga "-clip"
+                -- that starts with the hash and contains "-clip"
                 if file:find("^" .. base_name) and file:find("%-clip") and file:sub(-4) == ".pdf" then
                     local clip_name = file:gsub("%.pdf$", "")
                     table.insert(clips, clip_name)
@@ -284,7 +284,7 @@ local function set_lyscore(score)
             end
         end)
         
-        -- ordenamos si son varios sistemas.
+        -- Sort if there are several systems
         table.sort(clips, function(a, b)
             local num_a = a:match("%-clip%-(%d+)$")
             local num_b = b:match("%-clip%-(%d+)$")
@@ -298,7 +298,7 @@ local function set_lyscore(score)
             return a < b
         end)
         
-        -- inyectamos las rutas formateadas de forma idéntica a como las espera el backend de LaTeX
+        -- Inject formatted paths as expected by LaTeX backend
         for _, clip_file in ipairs(clips) do
             table.insert(score, score.tmpdir .. '/' .. clip_file)
         end
@@ -307,7 +307,7 @@ local function set_lyscore(score)
         score.range = {}
         for i = 1, score.nsystems do table.insert(score.range, i) end
 
-        -- borro todo archivo eps de este hash. solamente me quedo con los pdf
+        -- Remove all intermediate .eps files associated with this hash
         pcall(function()
             for file in lfs.dir(score.tmpdir) do
                 if file:find(base_name, 1, true) and file:sub(-4) == ".eps" then
@@ -318,7 +318,7 @@ local function set_lyscore(score)
         
         return
     end
-    -- fin fsarud
+    -- end fsarud
 
     ly.score.nsystems = ly.score:count_systems()
     if score.insert ~= 'fullpage' then
@@ -441,34 +441,34 @@ function latex_includesystems(filename, range, protrusion, gutter, staffsize, in
     local texoutput = '\\ifx\\preLilyPondExample\\undefined\\else\\preLilyPondExample\\fi\n'
     texoutput = texoutput..'\\par\n'
     
-    -- fsarud: clip-regions
+    -- fsarud:  if clip-regions is set
     local es_clip = ly.score and ly.score['clip-regions'] and ly.score['clip-regions'] ~= ''
 
     for index, system in pairs(range) do
-        local ruta_grafico
+        local path_graphic
         local h_space = h_offset + gutter
         
         if es_clip then
-            -- si es un clip, tomamos la ruta exacta y ordenada que guardamos en la tabla
-            ruta_grafico = ly.score[index]
-            h_offset = 0 -- anulo indentación. esto se puede mejorar
+            -- If it is a clip, we take the exact path ordered we stored in table
+            path_graphic = ly.score[index]
+            h_offset = 0 -- Override identation. This can be enhanced
             gutter = 0
-            -- salvaguarda: si por alguna razon no esta poblado, rompemos el bucle
-            if not ruta_grafico then break end
+            -- Just in case...
+            if not path_graphic then break end
         else
-            -- si es una partitura normal, usamos lo que hace originalmente lyluatex
+            -- If it is a normal score, we use the default lyluatex behavior
             if not lfs.isfile(filename..'-'..system..'.eps') then break end
-            ruta_grafico = filename..'-'..system
+            path_graphic = filename..'-'..system
         end
 
         texoutput = texoutput..
             string.format([[
 \noindent\hspace*{%fpt}\includegraphics{%s}%%
 ]],
-            h_offset + gutter,ruta_grafico
+            h_offset + gutter,path_graphic
             )
         if index < #range then
-    --fin fsarud 
+    --end fsarud 
 
             texoutput = texoutput..
                 string.format([[
@@ -869,7 +869,7 @@ function Score:count_systems(force)
         count = 0
         local base_name = self.output:match("[^/]*$")
         
-        -- fsarud: clip-systems. si es un clip, contamos los PDFs de clips generados (ya que los EPS se purgan)
+        -- fsarud: if clip-systems is set: count PDFs generated (EPS are no longer there)
         if self['clip-regions'] and self['clip-regions'] ~= '' then
             for f in lfs.dir(self.tmpdir) do
                 if f:find(base_name, 1, true) and f:find("-clip", 1, true) and f:sub(-4) == ".pdf" then
@@ -877,7 +877,7 @@ function Score:count_systems(force)
                 end
             end
         else
-            -- si no, va la lógica original para partituras estándar (busca .eps)
+            -- If not, original logic with EPS files
             local systems = base_name.."%-%d+%.eps"
             for f in lfs.dir(self.tmpdir) do
                 if f:match(systems) then
@@ -885,7 +885,7 @@ function Score:count_systems(force)
                 end
             end
         end
-        -- fin fsarud
+        -- end fsarud
         self.system_count = count
     end
     return count
@@ -952,17 +952,17 @@ function Score:header()
         end
     end
 
-    -- fsarud: clip-regions, inyecto el engraver al inicio y limpio el preamble
+    -- fsarud: if clip-regions is set, inyect engraver at start and adapt preamble
     if self['clip-regions'] and self['clip-regions'] ~= '' then
         header = CLIP_BREAK_ENGRAVER .. "\n" .. header
-    -- buscamos el include original y le pegamos abajo la redefinición del handler nativo
+    -- Look for the original include and paste below the modifier 
         header = header:gsub(
             [[%\include "lilypond%-book%-preamble.ly"]], 
             [[\include "lilypond-book-preamble.ly"
-                #(define default-toplevel-book-handler print-book-with-defaults)]] --esto es para que permita los clips con dclip-systems
+                #(define default-toplevel-book-handler print-book-with-defaults)]] --This is to allow dclip-systems
         )
     end
-    --- fin fsarud
+    --- end fsarud
 
     return header
 end
@@ -1228,14 +1228,14 @@ function Score:ly_staffprops()
     if self['clip-regions'] and self['clip-regions'] ~= '' then
         -- eliminamos espacios por las dudas y buscamos los números separados por guión
         local limpio = self['clip-regions']:gsub('%s+', '')
-        local inicio, fin = limpio:match("(%d+)%-(%d+)")
-        if inicio and fin then
+        local start, fin = limpio:match("(%d+)%-(%d+)")
+        if start and fin then
             clip_code = string.format([[
     clip-regions = #(list (cons (make-rhythmic-location %s 0 1) (make-rhythmic-location %s 0 1)))
     \context {
         \Score
         \consists \Clip_break_engraver
-    }]], inicio, tonumber(fin) + 1)
+    }]], start, tonumber(fin) + 1)
         else
             clip_code = '%% Wrong format for clip-regions. Should be start-end, e.g. 52-74 for measures 52 to 74. Ignoring.'
         end

--- a/lyluatex.sty
+++ b/lyluatex.sty
@@ -46,6 +46,7 @@
     ['addversion'] = {'false', 'true', ''},
     ['autoindent'] = {'true', 'false', ''},
     ['cleantmp'] = {'false', 'true', ''},
+    ['clip-regions'] = {''},
     ['currfiledir'] = {},
     ['debug'] = {'false', 'true', ''},
     ['extra-bottom-margin'] = {'0', _opt.is_dim},

--- a/test-clipregions.tex
+++ b/test-clipregions.tex
@@ -1,22 +1,22 @@
 \documentclass[a4paper,fontsize=12pt]{scrbook}
-\usepackage{fontspec}
-\usepackage{libertine}
 \usepackage[program=lilypond,debug]{lyluatex}
-\usepackage{multicol}
 
 \title{}
 \author{}
 
-
 \begin{document}
 
-Clip-regions
+    Clip-regions example
 
-\lilypondfile[staffsize=12, clip-regions=5-8 ]{ly/Beethoven/opus-18-1.ly}
+    \begin{enumerate}
+        \item Single system, no ragged--right
+        \lilypondfile[staffsize=12, clip-regions=6-10 ]{ly/Beethoven/opus-18-1.ly}
+    
+        \item Single system, ragged--right
+        \lilypondfile[staffsize=12, clip-regions=6-10, ragged-right=true]{ly/Beethoven/opus-18-1.ly}
 
-\lilypondfile[staffsize=12, clip-regions=4-7, ragged-right=true]{ly/Beethoven/opus-18-1.ly}
-
-\lilypondfile[clip-regions=1-15,ragged-right=true]{ly/Ave Maria De Lourdes/Ave Maria.ly}
-
+        \item Multiple system, ragged--right
+        \lilypondfile[clip-regions=2-15,ragged-right=true]{ly/Ave Maria De Lourdes/Ave Maria.ly}
+    \end{enumerate}
 
 \end{document}

--- a/test-clipregions.tex
+++ b/test-clipregions.tex
@@ -1,0 +1,22 @@
+\documentclass[a4paper,fontsize=12pt]{scrbook}
+\usepackage{fontspec}
+\usepackage{libertine}
+\usepackage[program=lilypond,debug]{lyluatex}
+\usepackage{multicol}
+
+\title{}
+\author{}
+
+
+\begin{document}
+
+Clip-regions
+
+\lilypondfile[staffsize=12, clip-regions=5-8 ]{ly/Beethoven/opus-18-1.ly}
+
+\lilypondfile[staffsize=12, clip-regions=4-7, ragged-right=true]{ly/Beethoven/opus-18-1.ly}
+
+\lilypondfile[clip-regions=1-15,ragged-right=true]{ly/Ave Maria De Lourdes/Ave Maria.ly}
+
+
+\end{document}

--- a/test-clipregions.tex
+++ b/test-clipregions.tex
@@ -1,5 +1,5 @@
 \documentclass[a4paper,fontsize=12pt]{scrbook}
-\usepackage[program=lilypond,debug]{lyluatex}
+\usepackage[program=lilypond]{lyluatex}
 
 \title{}
 \author{}
@@ -10,13 +10,14 @@
 
     \begin{enumerate}
         \item Single system, no ragged--right
-        \lilypondfile[staffsize=12, clip-regions=6-10 ]{ly/Beethoven/opus-18-1.ly}
+        \lilypondfile[staffsize=13, clip-regions=5-9 ]{ly/Beethoven/opus-18-1.ly}
     
         \item Single system, ragged--right
-        \lilypondfile[staffsize=12, clip-regions=6-10, ragged-right=true]{ly/Beethoven/opus-18-1.ly}
+        \lilypondfile[staffsize=14, clip-regions=5-9, ragged-right=true]{ly/Beethoven/opus-18-1.ly}
 
         \item Multiple system, ragged--right
-        \lilypondfile[clip-regions=2-15,ragged-right=true]{ly/Ave Maria De Lourdes/Ave Maria.ly}
+        \lilypondfile[clip-regions=2-14,ragged-right=true]{ly/Ave Maria De Lourdes/Ave Maria.ly}
+
     \end{enumerate}
 
 \end{document}


### PR DESCRIPTION
## Description
This PR adds native support for precise, measure-based score clipping using LilyPond's `-dclip-systems` backend. This is my first PR ever, so I kindly ask for some indulgence regarding any lack of experience on my part.

Previously, users had to rely on `print-only`, which compiles the entire score and filters pages. By bypassing `lilypond-book-preamble.ly`'s default book-handler specifically for clips, we are able to unlock LilyPond's native vector clipping system.

## Usage
`\lilypondfile[clip-regions=a-b]{file.ly}`
where `a` and `b` are the measures of the \score block in `file.ly` that you wish to clip.

The clip is forced to *begin a new system*, so sequential commands like `\lilypondfile[clip-regions=a-b]{file.ly}` and `\lilypondfile[clip-regions=c-d]{file.ly}` (with `a<>c` or `b<>d`) will generate two different hashes and compile completely independently of one another .

Usage with `ragged-right=true` is highly recommended.

## Changes Introduced
1. **Preamble Handler Override:** Intercepted `lilypond-book-preamble.ly` injection inside `Score:header()` to append `#(define default-toplevel-book-handler print-book-with-defaults)`, allowing `-dclip-systems` to work.
2. **Engraver Injection:** Automated the addition of `\consists \Clip_break_engraver` and `clip-regions` mapping inside the generated `\layout` block.
3. **CLI Flag:** Conditional insertion of the `-dclip-systems` flag in `Score:lilypond_cmd()` only when `clip-regions` is used.
4. **Deterministic Indexing:** Reworked `set_lyscore` and `latex_includesystems` to dynamically parse, sort, and inject the newly generated `*-clip.pdf`. `clip-regions` use the `.pdf`, not the `.eps`. This logic relies directly on the compiled `.pdf` vectors instead of the `.eps` files, and the latter are cleaned up to optimize space.

## Verification
Tested on Arch Linux using TeX Live 2026 and Lilypond 2.26.0. Works for both single-system and multi-system clips.